### PR TITLE
Add send/simulateTransaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ Example usage on localhost RPC testnet instance (note that instance must be runn
   --ramp-up 10s
 ```
 
+### Using `sendTransaction`
+
+The `sendTransaction` endpoint needs an origin account that can fund the worker accounts used during the run.
+
+On testnet, `stellar-rpc-blaster` can create and fund that origin account automatically through friendbot if `ORIGIN_ACCOUNT_SECRET` is unset.
+
+On pubnet, you must provide the funding account secret through the environment:
+
+```bash
+export ORIGIN_ACCOUNT_SECRET="S..."
+
+./stellar-rpc-blaster run \
+  --rpc-url "https://your-rpc-host" \
+  --config-path "./internal/config/config.example.toml" \
+  --duration 30s \
+  --ramp-up 10s
+```
+
+To target only `sendTransaction`, enable it in the TOML config and keep the secret out of the file:
+
+```toml
+input_data_path = "./output/seed.json"
+
+[endpoints.sendTransaction]
+rps = 10
+```
+
+Notes:
+- `sendTransaction` creates and funds worker accounts before the test starts, then merges them back into the origin account during cleanup.
+- The origin account must have enough XLM to fund the worker accounts and cover fees.
+- The tool logs the generated seed if it auto-creates an origin account on testnet.
+
 To generate data for the `generate` command, example usage is as follows:
 ```
 ./stellar-rpc-loadtest generate \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Notes:
 - `sendTransaction` creates and minimally funds worker accounts before the test starts, wraps worker transactions in fee bumps so the origin account pays the fees, then fee-bump-merges the workers back into the origin account during cleanup.
 - Worker accounts hold only the minimum balance needed to exist and authorize the inner transactions.
 - The origin account must have enough XLM to fund the worker accounts and cover setup, runtime, and cleanup fees.
+- If cleanup still cannot merge some workers after retrying, their seeds are written to `./output/unmerged_workers.json`.
 - The tool logs the generated seed if it auto-creates an origin account on testnet.
 
 To generate data for the `generate` command, example usage is as follows:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ rps = 10
 ```
 
 Notes:
-- `sendTransaction` creates and funds worker accounts before the test starts, then merges them back into the origin account during cleanup.
-- The origin account must have enough XLM to fund the worker accounts and cover fees.
+- `sendTransaction` creates and minimally funds worker accounts before the test starts, wraps worker transactions in fee bumps so the origin account pays the fees, then fee-bump-merges the workers back into the origin account during cleanup.
+- Worker accounts hold only the minimum balance needed to exist and authorize the inner transactions.
+- The origin account must have enough XLM to fund the worker accounts and cover setup, runtime, and cleanup fees.
 - The tool logs the generated seed if it auto-creates an origin account on testnet.
 
 To generate data for the `generate` command, example usage is as follows:

--- a/internal/app.go
+++ b/internal/app.go
@@ -118,7 +118,7 @@ func (a *App) runLoadTest(ctx context.Context) error {
 		aggregator.Run(ctx, out)
 	})
 
-	err := engine.RunVegeta(ctx, a.logger, a.config, a.client, out)
+	err := engine.RunVegeta(ctx, a.logger, a.config, a.client, out, aggregator.Start)
 	close(out)
 	wg.Wait()
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/stellar/go-stellar-sdk/support/log"
 
@@ -29,6 +30,9 @@ type App struct {
 	logger *log.Entry
 	config config.Config
 	client *http.Client
+
+	// Populated if in Run mode
+	blastEngine *engine.BlastEngine
 }
 
 func NewApp() *App {
@@ -103,14 +107,24 @@ func (a *App) init(ctx context.Context, runtimeSettings config.RuntimeSettings) 
 
 func (a *App) close() {
 	a.logger.Info("Shutting down Blaster")
-	// TODO: Clean up here if needed (e.g. close DB connection/metrics file)
-	// this isn't implemented yet
+	if a.blastEngine != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		if err := a.blastEngine.Close(ctx, a.logger); err != nil {
+			a.logger.Errorf("failed to close blast engine: %v", err)
+		}
+	}
 }
 
 func (a *App) runLoadTest(ctx context.Context) error {
 	out := make(chan blasterMetrics.Sample, 1000)
 
 	aggregator := blasterMetrics.NewAggregator(a.logger, a.config)
+	be, err := engine.NewBlastEngine(ctx, a.logger, a.config, a.client, out, aggregator.Start)
+	if err != nil {
+		return fmt.Errorf("failed to create blast engine: %v", err)
+	}
+	a.blastEngine = be
 
 	// Aggregator goroutine: consumes samples and prints every 5s
 	var wg sync.WaitGroup
@@ -118,8 +132,7 @@ func (a *App) runLoadTest(ctx context.Context) error {
 		aggregator.Run(ctx, out)
 	})
 
-	err := engine.RunVegeta(ctx, a.logger, a.config, a.client, out, aggregator.Start)
-	close(out)
+	be.FireBlasts(ctx)
 	wg.Wait()
 
 	return err

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -16,13 +16,13 @@ input_data_path = "./output/seed.json"
 rps = 0
 
 [endpoints.getNetwork]
-rps = 10
+rps = 0
 
 [endpoints.getVersionInfo]
 rps = 0
 
 [endpoints.getLatestLedger]
-rps = 10
+rps = 0
 
 [endpoints.getFeeStats]
 rps = 0
@@ -35,16 +35,16 @@ rps = 0
 rps = 0
 
 [endpoints.getLedgers]
-rps = 10
+rps = 0
 
 [endpoints.getTransaction]
-rps = 10
+rps = 0
 
 [endpoints.getTransactions]
-rps = 10
+rps = 0
 
 [endpoints.simulateTransaction]
-rps = 10
+rps = 0
 
 [endpoints.sendTransaction]
 rps = 10

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -16,13 +16,13 @@ input_data_path = "./output/seed.json"
 rps = 0
 
 [endpoints.getNetwork]
-rps = 0
+rps = 10
 
 [endpoints.getVersionInfo]
 rps = 0
 
 [endpoints.getLatestLedger]
-rps = 0
+rps = 10
 
 [endpoints.getFeeStats]
 rps = 0
@@ -38,13 +38,13 @@ rps = 0
 rps = 10
 
 [endpoints.getTransaction]
-rps = 0
+rps = 10
 
 [endpoints.getTransactions]
-rps = 0
+rps = 10
 
 [endpoints.simulateTransaction]
-rps = 0
+rps = 10
 
 [endpoints.sendTransaction]
 rps = 10

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -47,4 +47,4 @@ rps = 0
 rps = 0
 
 [endpoints.sendTransaction]
-rps = 10
+rps = 100

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -7,9 +7,9 @@
 # Using the default seed data output path, this is "./output/seed.json"
 input_data_path = "./output/seed.json"
 
-# Optional: secret seed (S...) for the origin account that funds worker accounts for sendTransaction.
+# Optional: set ORIGIN_ACCOUNT_SECRET in the environment for the origin account that funds worker accounts for sendTransaction.
 # Required for pubnet. On testnet, if omitted, a new account is created and funded via friendbot.
-origin_account_secret = "SATW2SA53PSQY35QHRRBADSXSOYJQ45HPV3Z7SDXH6X6CKRAXW4KVF3O"
+# Example: export ORIGIN_ACCOUNT_SECRET="S..."
 
 # No-parameter/run-only endpoints
 [endpoints.getHealth]

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -40,7 +40,7 @@ rps = 0
 rps = 0
 
 [endpoints.simulateTransaction]
-rps = 10
+rps = 0
 
 [endpoints.sendTransaction]
 rps = 10

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -9,7 +9,7 @@ input_data_path = "./output/seed.json"
 
 # Optional: secret seed (S...) for the origin account that funds worker accounts for sendTransaction.
 # Required for pubnet. On testnet, if omitted, a new account is created and funded via friendbot.
-# origin_account_secret = "S..."
+origin_account_secret = "SATW2SA53PSQY35QHRRBADSXSOYJQ45HPV3Z7SDXH6X6CKRAXW4KVF3O"
 
 # No-parameter/run-only endpoints
 [endpoints.getHealth]

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -9,29 +9,38 @@ input_data_path = "./output/seed.json"
 
 # No-parameter/run-only endpoints
 [endpoints.getHealth]
-rps = 1000
+rps = 0
 
 [endpoints.getNetwork]
-rps = 20
+rps = 0
 
 [endpoints.getVersionInfo]
-rps = 20
+rps = 0
 
 [endpoints.getLatestLedger]
-rps = 20
+rps = 0
 
 [endpoints.getFeeStats]
-rps = 20
+rps = 0
 
 # Parameter-based/generate-required endpoints
+[endpoints.getEvents] # this only takes optional arguments
+rps = 0
+
 [endpoints.getLedgerEntries]
-rps = 20
+rps = 0
 
 [endpoints.getLedgers]
-rps = 20
+rps = 10
 
 [endpoints.getTransaction]
-rps = 20
+rps = 0
 
 [endpoints.getTransactions]
-rps = 20
+rps = 0
+
+[endpoints.simulateTransaction]
+rps = 10
+
+[endpoints.sendTransaction]
+rps = 10

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -4,8 +4,12 @@
 #   rps          - requests per second
 # Specify the seed data input path for data dependent endpoints with:
 # data_path = "PATH/TO/INPUTDATA.json"
-# Using the default seed data output path, this is "./output/seed.json" 
+# Using the default seed data output path, this is "./output/seed.json"
 input_data_path = "./output/seed.json"
+
+# Optional: secret seed (S...) for the origin account that funds worker accounts for sendTransaction.
+# Required for pubnet. On testnet, if omitted, a new account is created and funded via friendbot.
+# origin_account_secret = "S..."
 
 # No-parameter/run-only endpoints
 [endpoints.getHealth]

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"os"
 	"slices"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters"
 )
+
+const OriginAccountSecretEnvVar = "ORIGIN_ACCOUNT_SECRET"
 
 type Config struct {
 	Endpoints map[string]EndpointConfig `toml:"endpoints"`
@@ -27,11 +30,10 @@ type Config struct {
 	Mode              Mode
 
 	// Run mode settings
-	Duration            time.Duration
-	RampUp              time.Duration
-	TestOutputPath      string        // path to write JSON results
-	OriginAccountSecret string        `toml:"origin_account_secret"` // Stellar secret seed (S...) for the origin funding account
-	OriginAccount       *keypair.Full // parsed from OriginAccountSecret; if nil, a new account will be generated (and funded via friendbot on testnet)
+	Duration       time.Duration
+	RampUp         time.Duration
+	TestOutputPath string        // path to write JSON results
+	OriginAccount  *keypair.Full // parsed from OriginAccountSecret if provided
 
 	// Generate mode settings
 	OutputPath   string
@@ -143,10 +145,11 @@ func (c *Config) processToml(tomlPath string) error {
 		if err = c.validateEndpointConfig(); err != nil {
 			return err
 		}
-		if c.OriginAccountSecret != "" {
-			kp, err := keypair.ParseFull(c.OriginAccountSecret)
+		originAccountSecret := os.Getenv(OriginAccountSecretEnvVar)
+		if originAccountSecret != "" {
+			kp, err := keypair.ParseFull(originAccountSecret)
 			if err != nil {
-				return fmt.Errorf("invalid origin_account_secret: %v", err)
+				return fmt.Errorf("invalid %s: %v", OriginAccountSecretEnvVar, err)
 			}
 			c.OriginAccount = kp
 		}

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -84,6 +84,8 @@ type EndpointConfig struct {
 	RPS int `toml:"rps"` // requests per second
 }
 
+// NewConfig loads the config from a TOML file, validates it, and returns a Config struct
+// Also initializes the RPC client and fetches the network passphrase.
 func NewConfig(
 	ctx context.Context,
 	settings RuntimeSettings,
@@ -124,6 +126,7 @@ func NewConfig(
 	return cfg, nil
 }
 
+// processToml loads the config from a TOML file and validates it. Called internally by NewConfig.
 func (c *Config) processToml(tomlPath string) error {
 	// Load config TOML file
 	cfg, err := toml.LoadFile(tomlPath)
@@ -171,13 +174,26 @@ func (c *Config) validateEndpointConfig() error {
 	return nil
 }
 
+// GetEndpoints returns a list of all endpoints specified in the config regardless of RPS
 func (c *Config) GetEndpoints() []string {
 	return slices.Collect(maps.Keys(c.Endpoints))
 }
 
+// GetEndpointRPS returns the RPS for a given endpoint key
 func (c *Config) GetEndpointRPS(key string) int {
 	if ep, ok := c.Endpoints[key]; ok {
 		return ep.RPS
 	}
 	return 0
+}
+
+// GetActiveEndpoints returns a list of endpoints targeted in a load test run.
+func (c *Config) GetActiveEndpoints() []string {
+	var activeEndpoints []string
+	for _, endpointKey := range c.GetEndpoints() {
+		if c.GetEndpointRPS(endpointKey) > 0 {
+			activeEndpoints = append(activeEndpoints, endpointKey)
+		}
+	}
+	return activeEndpoints
 }

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pelletier/go-toml"
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters"
 )
@@ -26,9 +27,11 @@ type Config struct {
 	Mode              Mode
 
 	// Run mode settings
-	Duration       time.Duration
-	RampUp         time.Duration
-	TestOutputPath string // path to write JSON results
+	Duration            time.Duration
+	RampUp              time.Duration
+	TestOutputPath      string        // path to write JSON results
+	OriginAccountSecret string        `toml:"origin_account_secret"` // Stellar secret seed (S...) for the origin funding account
+	OriginAccount       *keypair.Full // parsed from OriginAccountSecret; if nil, a new account will be generated (and funded via friendbot on testnet)
 
 	// Generate mode settings
 	OutputPath   string
@@ -136,6 +139,13 @@ func (c *Config) processToml(tomlPath string) error {
 	if c.Mode == Run {
 		if err = c.validateEndpointConfig(); err != nil {
 			return err
+		}
+		if c.OriginAccountSecret != "" {
+			kp, err := keypair.ParseFull(c.OriginAccountSecret)
+			if err != nil {
+				return fmt.Errorf("invalid origin_account_secret: %v", err)
+			}
+			c.OriginAccount = kp
 		}
 	}
 

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
@@ -56,23 +55,15 @@ func NewBlastEngine(
 		sharedParams.NetworkPassphrase = cfg.NetworkPassphrase
 	}
 
-	var activeEndpoints, skippedEndpoints []string
-	for _, endpointKey := range cfg.GetEndpoints() {
-		if cfg.GetEndpointRPS(endpointKey) <= 0 {
-			skippedEndpoints = append(skippedEndpoints, endpointKey)
-		} else {
-			activeEndpoints = append(activeEndpoints, endpointKey)
-		}
-	}
-	if len(skippedEndpoints) > 0 {
-		logger.Infof("Skipping endpoints with RPS<=0: %v", strings.Join(skippedEndpoints, ", "))
-	}
-
 	// Construct endpoint blast configs
 	var endpointBlasts []endpointBlast
 	var ap *tx.AccountPool
-	for _, endpointKey := range activeEndpoints {
+	for _, endpointKey := range cfg.GetEndpoints() {
 		rps := cfg.GetEndpointRPS(endpointKey)
+		if rps <= 0 {
+			logger.Infof("Skipping endpoint: %v (RPS <= 0)", endpointKey)
+			continue
+		}
 
 		var targeter vegeta.Targeter
 		if endpointKey == "sendTransaction" {

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -53,6 +53,7 @@ func NewBlastEngine(
 			return nil, fmt.Errorf("failed to load seed data: %v", err)
 		}
 		sharedParams = p
+		sharedParams.NetworkPassphrase = cfg.NetworkPassphrase
 	}
 
 	var activeEndpoints, skippedEndpoints []string

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -88,21 +88,14 @@ func NewBlastEngine(
 			// Need custom targeter to generate unique (tx, sequence) params for each request
 			targeter = NewSendTxTargeter(cfg.RpcUrl, ap, cfg.NetworkPassphrase)
 		} else {
-			paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
+			bodies, err := buildBodies(endpointKey, sharedParams)
 			if err != nil {
-				return nil, fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
+				return nil, err
 			}
-			bodies := make([][]byte, len(paramMaps))
-			for i, p := range paramMaps {
-				bodies[i], err = util.MarshalJsonRpcRequest(endpointKey, p)
-				if err != nil {
-					return nil, fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
-				}
-			}
-			targeter = NewJSONRPCTargeter(cfg.RpcUrl, bodies)
 			if len(bodies) > 1 {
 				logger.Infof("Endpoint %s: rotating through %d parameterized request bodies", endpointKey, len(bodies))
 			}
+			targeter = NewJSONRPCTargeter(cfg.RpcUrl, bodies)
 		}
 
 		endpointBlasts = append(endpointBlasts, endpointBlast{
@@ -127,6 +120,21 @@ func NewBlastEngine(
 		OutCh:             out,
 		Config:            cfg,
 	}, nil
+}
+
+func buildBodies(endpointKey string, sharedParams *parameters.Parameters) ([][]byte, error) {
+	paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
+	}
+	bodies := make([][]byte, len(paramMaps))
+	for i, p := range paramMaps {
+		bodies[i], err = util.MarshalJsonRpcRequest(endpointKey, p)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
+		}
+	}
+	return bodies, nil
 }
 
 func (b *BlastEngine) Close(ctx context.Context, logger *log.Entry) error {

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -18,22 +18,29 @@ import (
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
+type BlastEngine struct {
+	BlastSpecs        []endpointBlast
+	AggregatorStartFn func()
+	BlastFn           func() *vegeta.Attacker
+	TxAccountPool     *tx.AccountPool
+	OutCh             chan<- blasterMetrics.Sample
+	Config            config.Config
+}
+
 type endpointBlast struct {
 	EndpointBlastConfig EndpointBlastConfig
 	BlastPacer          RampToConstantPacer
 }
 
-// Entry/exit point from app.go
-// RunVegeta runs a load test using Vegeta using the config settings through the LoadTestSettings interface
-// Sets up shared HTTP client, constructs per-endpoint blast configs, and fires off the blasts asynchronously
-func RunVegeta(
+// Sets up shared HTTP client, constructs per-endpoint blast configs or targeters, and initializes the blast engine
+func NewBlastEngine(
 	ctx context.Context,
 	logger *log.Entry,
 	cfg config.Config,
 	httpClient *http.Client,
 	out chan<- blasterMetrics.Sample,
 	startAggregator func(),
-) error {
+) (*BlastEngine, error) {
 	newBlaster := func() *vegeta.Attacker {
 		return NewBlasterWithClient(httpClient, util.MaxWorkers)
 	}
@@ -43,7 +50,7 @@ func RunVegeta(
 	if cfg.InputDataPath != "" {
 		p, err := parameters.GetParameters(cfg.InputDataPath)
 		if err != nil {
-			return fmt.Errorf("failed to load seed data: %v", err)
+			return nil, fmt.Errorf("failed to load seed data: %v", err)
 		}
 		sharedParams = p
 	}
@@ -61,8 +68,8 @@ func RunVegeta(
 	}
 
 	// Construct endpoint blast configs
-	// 3... 2... 1...
 	var endpointBlasts []endpointBlast
+	var ap *tx.AccountPool
 	for _, endpointKey := range activeEndpoints {
 		rps := cfg.GetEndpointRPS(endpointKey)
 
@@ -72,22 +79,24 @@ func RunVegeta(
 
 			logger.Warn("sendTransaction causes greater load on the RPC server than other endpoints!")
 			logger.Infof("Creating + funding %d on-chain accounts for the sendTransaction endpoint...", numAccounts)
-			pool, err := tx.NewTestnetAccountPool(ctx, cfg.RpcClient, numAccounts) // create pool of accounts
+			var err error
+			ap, err = tx.NewTestnetAccountPool(ctx, cfg.RpcClient, nil, numAccounts) // create pool of accounts
 			if err != nil {
-				return fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
+				return nil, fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
 			}
+
 			// Need custom targeter to generate unique (tx, sequence) params for each request
-			targeter = NewSendTxTargeter(cfg.RpcUrl, pool, cfg.NetworkPassphrase)
+			targeter = NewSendTxTargeter(cfg.RpcUrl, ap, cfg.NetworkPassphrase)
 		} else {
 			paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
 			if err != nil {
-				return fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
+				return nil, fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
 			}
 			bodies := make([][]byte, len(paramMaps))
 			for i, p := range paramMaps {
 				bodies[i], err = util.MarshalJsonRpcRequest(endpointKey, p)
 				if err != nil {
-					return fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
+					return nil, fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
 				}
 			}
 			targeter = NewJSONRPCTargeter(cfg.RpcUrl, bodies)
@@ -110,21 +119,42 @@ func RunVegeta(
 			},
 		})
 	}
+	return &BlastEngine{
+		BlastSpecs:        endpointBlasts,
+		AggregatorStartFn: startAggregator,
+		BlastFn:           newBlaster,
+		TxAccountPool:     ap,
+		OutCh:             out,
+		Config:            cfg,
+	}, nil
+}
 
+func (b *BlastEngine) Close(ctx context.Context, logger *log.Entry) error {
+	if b.TxAccountPool != nil {
+		if err := b.TxAccountPool.Close(ctx, b.Config.RpcClient, logger); err != nil {
+			return fmt.Errorf("failed to close blast engine: %v", err)
+		}
+	}
+	return nil
+}
+
+// Runs a load test using Vegeta using the config settings through the BlastEngine struct
+func (b *BlastEngine) FireBlasts(ctx context.Context) error {
 	// Start the blast duration clock only after all setup is done
-	ctx, cancel := context.WithTimeout(ctx, cfg.Duration)
+	ctx, cancel := context.WithTimeout(ctx, b.Config.Duration)
 	defer cancel()
 
 	// Start the aggregator
-	startAggregator()
+	b.AggregatorStartFn()
 
 	// Fire!
 	var wg sync.WaitGroup
-	for _, blast := range endpointBlasts {
+	for _, blast := range b.BlastSpecs {
 		wg.Go(func() {
-			blastAtEndpoint(ctx, blast.EndpointBlastConfig, blast.BlastPacer, newBlaster, out)
+			blastAtEndpoint(ctx, blast.EndpointBlastConfig, blast.BlastPacer, b.BlastFn, b.OutCh)
 		})
 	}
 	wg.Wait()
+	close(b.OutCh)
 	return nil
 }

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -80,7 +80,7 @@ func NewBlastEngine(
 			logger.Warn("sendTransaction causes greater load on the RPC server than other endpoints!")
 			logger.Infof("Creating + funding %d on-chain accounts for the sendTransaction endpoint...", numAccounts)
 			var err error
-			ap, err = tx.NewTestnetAccountPool(ctx, cfg.RpcClient, nil, numAccounts) // create pool of accounts
+			ap, err = tx.NewAccountPool(ctx, cfg.RpcClient, cfg.OriginAccount, numAccounts) // create pool of accounts
 			if err != nil {
 				return nil, fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
 			}

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -72,7 +72,7 @@ func RunVegeta(
 
 			logger.Warn("sendTransaction causes greater load on the RPC server than other endpoints!")
 			logger.Infof("Creating + funding %d on-chain accounts for the sendTransaction endpoint...", numAccounts)
-			pool, err := tx.NewTestnetAccountPool(ctx, numAccounts, cfg.RpcClient) // create pool of accounts
+			pool, err := tx.NewTestnetAccountPool(ctx, cfg.RpcClient, numAccounts) // create pool of accounts
 			if err != nil {
 				return fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
 			}

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -2,9 +2,9 @@ package engine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
@@ -14,6 +14,7 @@ import (
 	"github.com/stellar/stellar-rpc-blaster/internal/config"
 	blasterMetrics "github.com/stellar/stellar-rpc-blaster/internal/run/metrics"
 	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters"
+	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters/tx"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
@@ -31,10 +32,8 @@ func RunVegeta(
 	cfg config.Config,
 	httpClient *http.Client,
 	out chan<- blasterMetrics.Sample,
+	startAggregator func(),
 ) error {
-	ctx, cancel := context.WithTimeout(ctx, cfg.Duration)
-	defer cancel()
-
 	newBlaster := func() *vegeta.Attacker {
 		return NewBlasterWithClient(httpClient, util.MaxWorkers)
 	}
@@ -49,37 +48,52 @@ func RunVegeta(
 		sharedParams = p
 	}
 
+	var activeEndpoints, skippedEndpoints []string
+	for _, endpointKey := range cfg.GetEndpoints() {
+		if cfg.GetEndpointRPS(endpointKey) <= 0 {
+			skippedEndpoints = append(skippedEndpoints, endpointKey)
+		} else {
+			activeEndpoints = append(activeEndpoints, endpointKey)
+		}
+	}
+	if len(skippedEndpoints) > 0 {
+		logger.Infof("Skipping endpoints with RPS<=0: %v", strings.Join(skippedEndpoints, ", "))
+	}
+
 	// Construct endpoint blast configs
 	// 3... 2... 1...
 	var endpointBlasts []endpointBlast
-	var skippedEndpoints []string
-	for _, endpointKey := range cfg.GetEndpoints() {
+	for _, endpointKey := range activeEndpoints {
 		rps := cfg.GetEndpointRPS(endpointKey)
-		if rps <= 0 {
-			skippedEndpoints = append(skippedEndpoints, endpointKey)
-			continue
-		}
 
-		paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
-		if err != nil {
-			return fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
-		}
-		bodies := make([][]byte, len(paramMaps))
-		for i, p := range paramMaps {
-			req := map[string]any{
-				"jsonrpc": "2.0",
-				"id":      1,
-				"method":  endpointKey,
-				"params":  p,
-			}
-			bodies[i], err = json.Marshal(req)
+		var targeter vegeta.Targeter
+		if endpointKey == "sendTransaction" {
+			numAccounts := uint32(min(rps, 100)) // cap # of accounts to lessen friendbot calls and account creation
+
+			logger.Warn("sendTransaction causes greater load on the RPC server than other endpoints!")
+			logger.Infof("Creating + funding %d on-chain accounts for the sendTransaction endpoint...", numAccounts)
+			pool, err := tx.NewTestnetAccountPool(ctx, numAccounts, cfg.RpcClient) // create pool of accounts
 			if err != nil {
-				return fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
+				return fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
 			}
-		}
-		targeter := NewJSONRPCTargeter(cfg.RpcUrl, bodies)
-		if len(bodies) > 1 {
-			logger.Infof("Endpoint %s: rotating through %d parameterized request bodies", endpointKey, len(bodies))
+			// Need custom targeter to generate unique (tx, sequence) params for each request
+			targeter = NewSendTxTargeter(cfg.RpcUrl, pool, cfg.NetworkPassphrase)
+		} else {
+			paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
+			if err != nil {
+				return fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
+			}
+			bodies := make([][]byte, len(paramMaps))
+			for i, p := range paramMaps {
+				bodies[i], err = util.MarshalJsonRpcRequest(endpointKey, p)
+				if err != nil {
+					return fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
+				}
+			}
+			targeter = NewJSONRPCTargeter(cfg.RpcUrl, bodies)
+			if len(bodies) > 1 {
+				logger.Infof("Endpoint %s: rotating through %d parameterized request bodies", endpointKey, len(bodies))
+			}
 		}
 
 		endpointBlasts = append(endpointBlasts, endpointBlast{
@@ -96,9 +110,13 @@ func RunVegeta(
 			},
 		})
 	}
-	if len(skippedEndpoints) > 0 {
-		logger.Infof("Skipping endpoints with RPS<=0: %v", skippedEndpoints)
-	}
+
+	// Start the blast duration clock only after all setup is done
+	ctx, cancel := context.WithTimeout(ctx, cfg.Duration)
+	defer cancel()
+
+	// Start the aggregator
+	startAggregator()
 
 	// Fire!
 	var wg sync.WaitGroup

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -72,7 +72,7 @@ func NewBlastEngine(
 			logger.Warn("sendTransaction causes greater load on the RPC server than other endpoints!")
 			logger.Infof("Creating + funding %d on-chain accounts for the sendTransaction endpoint...", numAccounts)
 			var err error
-			ap, err = tx.NewAccountPool(ctx, cfg.RpcClient, cfg.OriginAccount, numAccounts) // create pool of accounts
+			ap, err = tx.NewAccountPool(ctx, logger, cfg.RpcClient, cfg.OriginAccount, numAccounts) // create pool of accounts
 			if err != nil {
 				return nil, fmt.Errorf("failed to create account pool for sendTransaction: %v", err)
 			}

--- a/internal/run/engine/targets.go
+++ b/internal/run/engine/targets.go
@@ -28,8 +28,12 @@ func NewJSONRPCTargeter(rpcURL string, bodies [][]byte) vegeta.Targeter {
 
 func NewSendTxTargeter(rpcURL string, pool *tx.AccountPool, networkPassphrase string) vegeta.Targeter {
 	return func(t *vegeta.Target) error {
-		acct, seq := pool.Next()                                          // round-robin pick an account and get its current sequence number
-		txB64, err := tx.BuildSelfSendTxB64(acct, seq, networkPassphrase) // build + sign
+		acct, seq := pool.Next() // round-robin pick an account and get its current sequence number
+		innerTx, err := tx.BuildSelfSendTx(acct, seq, networkPassphrase)
+		if err != nil {
+			return err
+		}
+		txB64, err := pool.WrapWithOriginFeeBumpB64(innerTx)
 		if err != nil {
 			return err
 		}

--- a/internal/run/engine/targets.go
+++ b/internal/run/engine/targets.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 	"sync/atomic"
 
+	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters/tx"
+	"github.com/stellar/stellar-rpc-blaster/internal/util"
+
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
@@ -16,6 +19,27 @@ func NewJSONRPCTargeter(rpcURL string, bodies [][]byte) vegeta.Targeter {
 		t.Method = http.MethodPost
 		t.URL = rpcURL
 		t.Body = bodies[i%uint64(len(bodies))]
+		t.Header = http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return nil
+	}
+}
+
+func NewSendTxTargeter(rpcURL string, pool *tx.AccountPool, networkPassphrase string) vegeta.Targeter {
+	return func(t *vegeta.Target) error {
+		acct, seq := pool.Next()                                      // round-robin pick an account and get its current sequence number
+		txB64, err := tx.BuildSendTxB64(acct, seq, networkPassphrase) // build + sign
+		if err != nil {
+			return err
+		}
+		body, err := util.MarshalJsonRpcRequest("sendTransaction", map[string]any{"transaction": txB64})
+		if err != nil {
+			return err
+		}
+		t.Method = http.MethodPost
+		t.URL = rpcURL
+		t.Body = body
 		t.Header = http.Header{
 			"Content-Type": []string{"application/json"},
 		}

--- a/internal/run/engine/targets.go
+++ b/internal/run/engine/targets.go
@@ -28,8 +28,8 @@ func NewJSONRPCTargeter(rpcURL string, bodies [][]byte) vegeta.Targeter {
 
 func NewSendTxTargeter(rpcURL string, pool *tx.AccountPool, networkPassphrase string) vegeta.Targeter {
 	return func(t *vegeta.Target) error {
-		acct, seq := pool.Next()                                      // round-robin pick an account and get its current sequence number
-		txB64, err := tx.BuildSendTxB64(acct, seq, networkPassphrase) // build + sign
+		acct, seq := pool.Next()                                          // round-robin pick an account and get its current sequence number
+		txB64, err := tx.BuildSelfSendTxB64(acct, seq, networkPassphrase) // build + sign
 		if err != nil {
 			return err
 		}

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -27,6 +27,7 @@ type Aggregator struct {
 	orderedEndpoints []string
 
 	start    time.Time
+	startCh  chan struct{}
 	duration time.Duration
 	mu       sync.RWMutex
 }
@@ -44,16 +45,20 @@ type EndpointStats struct {
 
 // Main driver function; consumes samples from the channel and prints progress every 5 seconds
 func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
+	// Wait for Start() before ticking
+	<-a.startCh
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
-	started := false
 
+	printed := false
 	for {
 		select {
 		case sample, ok := <-in:
 			if !ok {
 				// channel closed — print final results and write output
-				a.logger.Info(a)
+				if !printed {
+					a.logger.Info(a)
+				}
 				if err := WriteOutput(a); err != nil {
 					a.logger.Error(err)
 				}
@@ -63,15 +68,13 @@ func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 				a.logger.Error(err)
 			}
 		case <-ticker.C:
-			if a.start.IsZero() {
-				continue
-			}
-			if !started {
-				started = true
-				ticker.Reset(5 * time.Second) // realign ticker to blast start
+			if printed {
 				continue
 			}
 			a.logger.Info(a)
+			if time.Since(a.start) >= a.duration {
+				printed = true
+			}
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
 				a.logger.Errorf("aggregator.Run terminating due to context error: %v", err)
@@ -86,13 +89,14 @@ func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 
 func (a *Aggregator) Start() {
 	a.start = time.Now()
+	close(a.startCh)
 }
 
 func NewAggregator(logger *log.Entry, settings config.Config) *Aggregator {
 	a := Aggregator{
 		logger:          logger,
 		stats:           make(map[string]*EndpointStats),
-		start:           time.Time{},
+		startCh:         make(chan struct{}),
 		duration:        settings.Duration,
 		writeOutputPath: settings.TestOutputPath,
 	}

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -46,12 +46,14 @@ type EndpointStats struct {
 func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	started := false
 
 	for {
 		select {
 		case sample, ok := <-in:
 			if !ok {
-				// channel closed
+				// channel closed — print final results and write output
+				a.logger.Info(a)
 				if err := WriteOutput(a); err != nil {
 					a.logger.Error(err)
 				}
@@ -61,6 +63,14 @@ func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 				a.logger.Error(err)
 			}
 		case <-ticker.C:
+			if a.start.IsZero() {
+				continue
+			}
+			if !started {
+				started = true
+				ticker.Reset(5 * time.Second) // realign ticker to blast start
+				continue
+			}
 			a.logger.Info(a)
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
@@ -74,15 +84,25 @@ func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 	}
 }
 
+func (a *Aggregator) Start() {
+	a.start = time.Now()
+}
+
 func NewAggregator(logger *log.Entry, settings config.Config) *Aggregator {
 	a := Aggregator{
 		logger:          logger,
 		stats:           make(map[string]*EndpointStats),
-		start:           time.Now(),
+		start:           time.Time{},
 		duration:        settings.Duration,
 		writeOutputPath: settings.TestOutputPath,
 	}
-	endpoints := settings.GetEndpoints()
+	allEndpoints := settings.GetEndpoints()
+	var endpoints []string
+	for _, endpointKey := range allEndpoints {
+		if settings.GetEndpointRPS(endpointKey) > 0 {
+			endpoints = append(endpoints, endpointKey)
+		}
+	}
 	sort.Strings(endpoints)
 	a.orderedEndpoints = endpoints // maintain order for consistent output
 

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -100,13 +100,7 @@ func NewAggregator(logger *log.Entry, settings config.Config) *Aggregator {
 		duration:        settings.Duration,
 		writeOutputPath: settings.TestOutputPath,
 	}
-	allEndpoints := settings.GetEndpoints()
-	var endpoints []string
-	for _, endpointKey := range allEndpoints {
-		if settings.GetEndpointRPS(endpointKey) > 0 {
-			endpoints = append(endpoints, endpointKey)
-		}
-	}
+	endpoints := settings.GetActiveEndpoints()
 	sort.Strings(endpoints)
 	a.orderedEndpoints = endpoints // maintain order for consistent output
 

--- a/internal/run/parameters/endpoints.go
+++ b/internal/run/parameters/endpoints.go
@@ -6,19 +6,21 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/toid"
 
+	"github.com/stellar/stellar-rpc-blaster/internal/run/parameters/tx"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
 // Builds a list of params maps for a data-dependent endpoint,
 // one per seed item, so the targeter can rotate through distinct request payloads.
 func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]any, error) {
-	if needs, err := EndpointNeedsData(endpointKey); err != nil {
-		return nil, err
-	} else if !needs {
-		return []map[string]any{{}}, nil
-	}
-
 	switch endpointKey {
+	case "simulateTransaction":
+		txB64, err := tx.BuildSimulateTxB64()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build simulate tx: %v", err)
+		}
+		return []map[string]any{{"transaction": txB64}}, nil
+
 	case "getTransaction":
 		txs := params.Output.TxHashes
 		var result []map[string]any
@@ -88,6 +90,9 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 	case "getEvents":
 		return nil, fmt.Errorf("getEvents endpoint not yet implemented")
 
+	case "getHealth", "getNetwork", "getVersionInfo", "getLatestLedger", "getFeeStats", "sendTransaction":
+		return []map[string]any{{}}, nil
+
 	default:
 		return nil, fmt.Errorf("unsupported endpoint %s", endpointKey)
 	}
@@ -96,9 +101,9 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 // EndpointNeedsData reports whether the endpoint requires seed data to build requests.
 func EndpointNeedsData(endpointKey string) (bool, error) {
 	switch endpointKey {
-	case "getTransaction", "getLedgerEntries", "getTransactions", "getLedgers", "getEvents", "simulateTransaction":
+	case "getTransaction", "getLedgerEntries", "getTransactions", "getLedgers", "getEvents":
 		return true, nil
-	case "getHealth", "getNetwork", "getVersionInfo", "getLatestLedger", "getFeeStats", "sendTransaction":
+	case "getHealth", "getNetwork", "getVersionInfo", "getLatestLedger", "getFeeStats", "sendTransaction", "simulateTransaction":
 		return false, nil
 	default:
 		return false, fmt.Errorf("unknown endpoint %q", endpointKey)

--- a/internal/run/parameters/endpoints.go
+++ b/internal/run/parameters/endpoints.go
@@ -15,7 +15,7 @@ import (
 func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]any, error) {
 	switch endpointKey {
 	case "simulateTransaction":
-		txB64, err := tx.BuildSimulateTxB64()
+		txB64, err := tx.BuildSimulateTxB64(params.NetworkPassphrase)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build simulate tx: %v", err)
 		}

--- a/internal/run/parameters/endpoints.go
+++ b/internal/run/parameters/endpoints.go
@@ -98,7 +98,7 @@ func EndpointNeedsData(endpointKey string) (bool, error) {
 	switch endpointKey {
 	case "getTransaction", "getLedgerEntries", "getTransactions", "getLedgers", "getEvents", "simulateTransaction":
 		return true, nil
-	case "getHealth", "getNetwork", "getVersionInfo", "getLatestLedger", "getFeeStats":
+	case "getHealth", "getNetwork", "getVersionInfo", "getLatestLedger", "getFeeStats", "sendTransaction":
 		return false, nil
 	default:
 		return false, fmt.Errorf("unknown endpoint %q", endpointKey)

--- a/internal/run/parameters/load.go
+++ b/internal/run/parameters/load.go
@@ -10,8 +10,9 @@ import (
 )
 
 type Parameters struct {
-	Output       seed.SeedData
-	SampleCounts map[string]int
+	Output            seed.SeedData
+	SampleCounts      map[string]int
+	NetworkPassphrase string
 }
 
 func GetParameters(dataPath string) (*Parameters, error) {

--- a/internal/run/parameters/tx/accounts.go
+++ b/internal/run/parameters/tx/accounts.go
@@ -64,12 +64,18 @@ func (w *WorkerAccount) MergeInto(ctx context.Context, pool *AccountPool, to *Wo
 	return resp.Hash, nil
 }
 
-func (w *WorkerAccount) CreateAccountFor(ctx context.Context, pool *AccountPool, to *WorkerAccount, amount int64, networkPassphrase string) (string, error) {
+func (w *WorkerAccount) CreateAccountsFor(
+	ctx context.Context,
+	pool *AccountPool,
+	to []*WorkerAccount,
+	amount int64,
+	networkPassphrase string,
+) (string, error) {
 	seq, err := w.fetchOnChainSeq(ctx, pool.rpcClient)
 	if err != nil {
 		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
 	}
-	txB64, err := BuildCreateAccountTxB64(w, to, amount, seq, networkPassphrase)
+	txB64, err := BuildCreateAccountsTxB64(w, to, amount, seq, networkPassphrase)
 	if err != nil {
 		return "", fmt.Errorf("failed to build create account tx: %v", err)
 	}
@@ -81,8 +87,10 @@ func (w *WorkerAccount) CreateAccountFor(ctx context.Context, pool *AccountPool,
 		return "", fmt.Errorf("create account transaction rejected: %s", resp.ErrorResultXDR)
 	}
 	w.Id.Store(seq + 1)
-	w.Balance.Swap(w.Balance.Load() - amount)
-	to.Balance.Store(amount)
+	w.Balance.Swap(w.Balance.Load() - amount*int64(len(to)))
+	for _, acct := range to {
+		acct.Balance.Store(amount)
+	}
 	return resp.Hash, nil
 }
 

--- a/internal/run/parameters/tx/accounts.go
+++ b/internal/run/parameters/tx/accounts.go
@@ -5,90 +5,84 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
 type WorkerAccount struct {
 	Keypair *keypair.Full
-	Id      atomic.Int64 // unique ID incr per tx
+	Id      atomic.Int64  // unique ID incr per tx
+	Balance atomic.Uint64 // track balance
 }
 
-type AccountPool struct {
-	accounts []*WorkerAccount
-	idx      int64 // atomically incr index to rotate through accounts
-	mu       sync.Mutex
-}
-
-// Makes a pool of workers and funds each of them with testnet friendbot XLM
-func NewTestnetAccountPool(
-	ctx context.Context,
-	numAccounts uint32,
-	rpcClient *rpcclient.Client,
-) (*AccountPool, error) {
-	friendbotUrlReq, err := rpcClient.GetNetwork(ctx)
+func (w *WorkerAccount) SendPaymentTo(ctx context.Context, pool *AccountPool, to *WorkerAccount, amount uint64, networkPassphrase string) error {
+	txB64, err := BuildSendPaymentTxB64(w, to, amount, w.Id.Load(), networkPassphrase)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get friendbot URL: %v", err)
-	} else if friendbotUrlReq.FriendbotURL == "" {
-		return nil, fmt.Errorf("network does not have friendbot URL (check RPC config?)")
+		return fmt.Errorf("failed to build XDR for funding payment: %v", err)
 	}
-
-	// Generate keypairs and fund all accounts
-	accounts := make([]*WorkerAccount, numAccounts)
-	for i := range accounts {
-		kp, err := keypair.Random()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
-		}
-		accounts[i] = &WorkerAccount{Keypair: kp}
-
-		if err := fundTestnetAccount(kp.Address(), friendbotUrlReq.FriendbotURL); err != nil {
-			return nil, fmt.Errorf("failed to fund account %s: %v", kp.Address(), err)
-		}
+	if _, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64)); err != nil {
+		return fmt.Errorf("failed to submit funding transaction: %v", err)
 	}
-
-	// Wait for ledger close so all accounts visible on-chain, then fetch all sequence numbers
-	for attempt := range 10 {
-		allFound := true
-		for _, acct := range accounts {
-			if acct.Id.Load() != 0 {
-				continue // already resolved
-			}
-			seq, err := getAccountSeq(ctx, acct, rpcClient)
-			if err != nil {
-				allFound = false
-				continue
-			}
-			acct.Id.Store(seq)
-		}
-		if allFound {
-			break
-		}
-		if attempt == 9 {
-			return nil, fmt.Errorf("some accounts not visible on-chain after funding")
-		}
-		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
-	}
-
-	return &AccountPool{accounts: accounts}, nil
+	w.Id.Add(1) // increment sequence for next tx
+	w.Balance.Swap(w.Balance.Load() - amount)
+	to.Balance.Add(amount)
+	return nil
 }
 
-// Get the next account and its current sequence number, and increment the sequence for the next call
-func (p *AccountPool) Next() (*WorkerAccount, int64) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	i := p.idx
-	acct := p.accounts[i%int64(len(p.accounts))]
-	p.idx++
-	return acct, acct.Id.Add(1) - 1
+func (w *WorkerAccount) GetAccountBalance(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
+	accountID, err := xdr.AddressToAccountId(w.Keypair.Address())
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert address to account ID: %v", err)
+	}
+	lk, err := accountID.LedgerKey()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get ledger key: %v", err)
+	}
+	accountKey, err := xdr.MarshalBase64(lk)
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal ledger key: %v", err)
+	}
+
+	resp, err := rpcClient.GetLedgerEntries(ctx, protocol.GetLedgerEntriesRequest{
+		Keys: []string{accountKey},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get ledger entries: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		return 0, fmt.Errorf("account %s not found", w.Keypair.Address())
+	}
+
+	var entry xdr.LedgerEntryData
+	if err := xdr.SafeUnmarshalBase64(resp.Entries[0].DataXDR, &entry); err != nil {
+		return 0, fmt.Errorf("failed to unmarshal ledger entry data: %v", err)
+	}
+	return int64(entry.Account.Balance), nil // balance in stroops (1 XLM = 10^7 stroops)
 }
 
-func fundTestnetAccount(address string, friendbotURL string) error {
-	resp, err := http.Get(friendbotURL + "?" + url.Values{"addr": []string{address}}.Encode())
+func (w *WorkerAccount) getAccountSeq(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
+	if seq := w.Id.Load(); seq > 0 {
+		return seq, nil
+	}
+	accountDetail, err := rpcClient.LoadAccount(ctx, w.Keypair.Address())
+	if err != nil {
+		return 0, fmt.Errorf("failed to get account detail for %s: %v", w.Keypair.Address(), err)
+	}
+	seq, err := accountDetail.GetSequenceNumber()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get sequence number for %s: %v", w.Keypair.Address(), err)
+	}
+	return seq, nil
+}
+
+func (w *WorkerAccount) fundTestnetAccount(friendbotURL string) error {
+	resp, err := http.Get(friendbotURL + "?" + url.Values{"addr": []string{w.Keypair.Address()}}.Encode())
 	if err != nil {
 		return fmt.Errorf("friendbot request failed: %v", err)
 	}
@@ -101,14 +95,26 @@ func fundTestnetAccount(address string, friendbotURL string) error {
 	return nil
 }
 
-func getAccountSeq(ctx context.Context, account *WorkerAccount, rpcClient *rpcclient.Client) (int64, error) {
-	accountDetail, err := rpcClient.LoadAccount(ctx, account.Keypair.Address())
-	if err != nil {
-		return 0, fmt.Errorf("failed to get account detail for %s: %v", account.Keypair.Address(), err)
+func VerifyOnChainAndStore(ctx context.Context, rpcClient *rpcclient.Client, accounts []*WorkerAccount) (bool, error) {
+	for attempt := range 10 {
+		var err error
+		allFound := true
+		for _, acct := range accounts {
+			if seq, err := acct.getAccountSeq(ctx, rpcClient); err != nil || seq <= 0 {
+				allFound = false
+				continue
+			} else {
+				acct.Id.Store(seq)
+			}
+		}
+		if allFound {
+			break
+		}
+		if attempt == 9 {
+			return false, fmt.Errorf("some accounts not visible on-chain after funding: %v", err)
+		}
+		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
 	}
-	seq, err := accountDetail.GetSequenceNumber()
-	if err != nil {
-		return 0, fmt.Errorf("failed to get sequence number for %s: %v", account.Keypair.Address(), err)
-	}
-	return seq, nil
+
+	return true, nil
 }

--- a/internal/run/parameters/tx/accounts.go
+++ b/internal/run/parameters/tx/accounts.go
@@ -33,9 +33,13 @@ func (w *WorkerAccount) SendPaymentTo(
 	if err != nil {
 		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
 	}
-	txB64, err := BuildSendPaymentTxB64(w, to, amount, seq, networkPassphrase)
+	tx, err := BuildSendPaymentTx(w, to, amount, seq, networkPassphrase)
 	if err != nil {
 		return "", fmt.Errorf("failed to build XDR for funding payment: %v", err)
+	}
+	txB64, err := tx.Base64()
+	if err != nil {
+		return "", fmt.Errorf("failed to encode transaction to base64: %v", err)
 	}
 	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
 	if err != nil {
@@ -48,14 +52,19 @@ func (w *WorkerAccount) SendPaymentTo(
 }
 
 // MergeInto closes this account and transfers all remaining funds to the destination account.
-func (w *WorkerAccount) MergeInto(ctx context.Context, pool *AccountPool, to *WorkerAccount, networkPassphrase string) (string, error) {
+func (w *WorkerAccount) MergeInto(ctx context.Context, pool *AccountPool, to *WorkerAccount) (string, error) {
 	seq, err := w.fetchOnChainSeq(ctx, pool.rpcClient)
 	if err != nil {
 		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
 	}
-	txB64, err := BuildAccountMergeTxB64(w, to, seq, networkPassphrase)
+
+	innerTx, err := BuildAccountMergeTx(w, to, seq, pool.passphrase)
 	if err != nil {
 		return "", fmt.Errorf("failed to build account merge tx: %v", err)
+	}
+	txB64, err := pool.WrapWithOriginFeeBumpB64(innerTx)
+	if err != nil {
+		return "", fmt.Errorf("failed to wrap account merge tx with origin fee bump: %v", err)
 	}
 	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
 	if err != nil {
@@ -75,10 +84,16 @@ func (w *WorkerAccount) CreateAccountsFor(
 	if err != nil {
 		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
 	}
-	txB64, err := BuildCreateAccountsTxB64(w, to, amount, seq, networkPassphrase)
+
+	tx, err := BuildCreateAccountsTx(w, to, amount, seq, networkPassphrase)
 	if err != nil {
 		return "", fmt.Errorf("failed to build create account tx: %v", err)
 	}
+	txB64, err := tx.Base64()
+	if err != nil {
+		return "", fmt.Errorf("failed to encode transaction to base64: %v", err)
+	}
+
 	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
 	if err != nil {
 		return "", fmt.Errorf("failed to submit create account transaction: %v", err)
@@ -86,6 +101,7 @@ func (w *WorkerAccount) CreateAccountsFor(
 	if resp.Status == proto.TXStatusError {
 		return "", fmt.Errorf("create account transaction rejected: %s", resp.ErrorResultXDR)
 	}
+
 	w.Id.Store(seq + 1)
 	w.Balance.Swap(w.Balance.Load() - amount*int64(len(to)))
 	for _, acct := range to {
@@ -150,7 +166,7 @@ func (w *WorkerAccount) GetOnChainBalance(ctx context.Context, rpcClient *rpccli
 	}
 	xlmBalance := entry.Account.Balance / util.StroopsPerXLM
 
-	return int64(xlmBalance), nil // balance in stroops (1 XLM = 10^7 stroops)
+	return int64(xlmBalance), nil // balance in whole XLM units
 }
 
 // fetchOnChainSeq always fetches the current sequence from the network.

--- a/internal/run/parameters/tx/accounts.go
+++ b/internal/run/parameters/tx/accounts.go
@@ -1,0 +1,114 @@
+package tx
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	"github.com/stellar/go-stellar-sdk/keypair"
+)
+
+type WorkerAccount struct {
+	Keypair *keypair.Full
+	Id      atomic.Int64 // unique ID incr per tx
+}
+
+type AccountPool struct {
+	accounts []*WorkerAccount
+	idx      int64 // atomically incr index to rotate through accounts
+	mu       sync.Mutex
+}
+
+// Makes a pool of workers and funds each of them with testnet friendbot XLM
+func NewTestnetAccountPool(
+	ctx context.Context,
+	numAccounts uint32,
+	rpcClient *rpcclient.Client,
+) (*AccountPool, error) {
+	friendbotUrlReq, err := rpcClient.GetNetwork(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get friendbot URL: %v", err)
+	} else if friendbotUrlReq.FriendbotURL == "" {
+		return nil, fmt.Errorf("network does not have friendbot URL (check RPC config?)")
+	}
+
+	// Generate keypairs and fund all accounts
+	accounts := make([]*WorkerAccount, numAccounts)
+	for i := range accounts {
+		kp, err := keypair.Random()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
+		}
+		accounts[i] = &WorkerAccount{Keypair: kp}
+
+		if err := fundTestnetAccount(kp.Address(), friendbotUrlReq.FriendbotURL); err != nil {
+			return nil, fmt.Errorf("failed to fund account %s: %v", kp.Address(), err)
+		}
+	}
+
+	// Wait for ledger close so all accounts visible on-chain, then fetch all sequence numbers
+	for attempt := range 10 {
+		allFound := true
+		for _, acct := range accounts {
+			if acct.Id.Load() != 0 {
+				continue // already resolved
+			}
+			seq, err := getAccountSeq(ctx, acct, rpcClient)
+			if err != nil {
+				allFound = false
+				continue
+			}
+			acct.Id.Store(seq)
+		}
+		if allFound {
+			break
+		}
+		if attempt == 9 {
+			return nil, fmt.Errorf("some accounts not visible on-chain after funding")
+		}
+		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+	}
+
+	return &AccountPool{accounts: accounts}, nil
+}
+
+// Get the next account and its current sequence number, and increment the sequence for the next call
+func (p *AccountPool) Next() (*WorkerAccount, int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	i := p.idx
+	acct := p.accounts[i%int64(len(p.accounts))]
+	p.idx++
+	return acct, acct.Id.Add(1) - 1
+}
+
+func fundTestnetAccount(address string, friendbotURL string) error {
+	resp, err := http.Get(friendbotURL + "?" + url.Values{"addr": []string{address}}.Encode())
+	if err != nil {
+		return fmt.Errorf("friendbot request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("friendbot returned non-200 status: %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func getAccountSeq(ctx context.Context, account *WorkerAccount, rpcClient *rpcclient.Client) (int64, error) {
+	accountDetail, err := rpcClient.LoadAccount(ctx, account.Keypair.Address())
+	if err != nil {
+		return 0, fmt.Errorf("failed to get account detail for %s: %v", account.Keypair.Address(), err)
+	}
+	seq, err := accountDetail.GetSequenceNumber()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get sequence number for %s: %v", account.Keypair.Address(), err)
+	}
+	return seq, nil
+}

--- a/internal/run/parameters/tx/accounts.go
+++ b/internal/run/parameters/tx/accounts.go
@@ -11,31 +11,108 @@ import (
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	proto "github.com/stellar/go-stellar-sdk/protocols/stellarcore"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
 type WorkerAccount struct {
 	Keypair *keypair.Full
-	Id      atomic.Int64  // unique ID incr per tx
-	Balance atomic.Uint64 // track balance
+	Id      atomic.Int64 // unique ID incr per tx
+	Balance atomic.Int64 // track balance
 }
 
-func (w *WorkerAccount) SendPaymentTo(ctx context.Context, pool *AccountPool, to *WorkerAccount, amount uint64, networkPassphrase string) error {
-	txB64, err := BuildSendPaymentTxB64(w, to, amount, w.Id.Load(), networkPassphrase)
+func (w *WorkerAccount) SendPaymentTo(
+	ctx context.Context,
+	pool *AccountPool,
+	to *WorkerAccount,
+	amount int64,
+	networkPassphrase string,
+) (string, error) {
+	seq, err := w.fetchOnChainSeq(ctx, pool.rpcClient)
 	if err != nil {
-		return fmt.Errorf("failed to build XDR for funding payment: %v", err)
+		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
 	}
-	if _, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64)); err != nil {
-		return fmt.Errorf("failed to submit funding transaction: %v", err)
+	txB64, err := BuildSendPaymentTxB64(w, to, amount, seq, networkPassphrase)
+	if err != nil {
+		return "", fmt.Errorf("failed to build XDR for funding payment: %v", err)
 	}
-	w.Id.Add(1) // increment sequence for next tx
+	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
+	if err != nil {
+		return "", fmt.Errorf("failed to submit funding transaction: %v", err)
+	}
+	w.Id.Store(seq + 1) // store confirmed next sequence
 	w.Balance.Swap(w.Balance.Load() - amount)
 	to.Balance.Add(amount)
+	return resp.Hash, nil
+}
+
+// MergeInto closes this account and transfers all remaining funds to the destination account.
+func (w *WorkerAccount) MergeInto(ctx context.Context, pool *AccountPool, to *WorkerAccount, networkPassphrase string) (string, error) {
+	seq, err := w.fetchOnChainSeq(ctx, pool.rpcClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
+	}
+	txB64, err := BuildAccountMergeTxB64(w, to, seq, networkPassphrase)
+	if err != nil {
+		return "", fmt.Errorf("failed to build account merge tx: %v", err)
+	}
+	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
+	if err != nil {
+		return "", fmt.Errorf("failed to submit account merge transaction: %v", err)
+	}
+	return resp.Hash, nil
+}
+
+func (w *WorkerAccount) CreateAccountFor(ctx context.Context, pool *AccountPool, to *WorkerAccount, amount int64, networkPassphrase string) (string, error) {
+	seq, err := w.fetchOnChainSeq(ctx, pool.rpcClient)
+	if err != nil {
+		return "", fmt.Errorf("failed to get on-chain sequence for %s: %v", w.Keypair.Address(), err)
+	}
+	txB64, err := BuildCreateAccountTxB64(w, to, amount, seq, networkPassphrase)
+	if err != nil {
+		return "", fmt.Errorf("failed to build create account tx: %v", err)
+	}
+	resp, err := pool.rpcClient.SendTransaction(ctx, util.MakeSendTransactionRequest(txB64))
+	if err != nil {
+		return "", fmt.Errorf("failed to submit create account transaction: %v", err)
+	}
+	if resp.Status == proto.TXStatusError {
+		return "", fmt.Errorf("create account transaction rejected: %s", resp.ErrorResultXDR)
+	}
+	w.Id.Store(seq + 1)
+	w.Balance.Swap(w.Balance.Load() - amount)
+	to.Balance.Store(amount)
+	return resp.Hash, nil
+}
+
+// awaitTxConfirmation polls getTransaction for each hash until it is confirmed on-chain (SUCCESS or FAILED).
+// sendTransaction is async, so this is needed to ensure accounts exist before using them.
+func awaitTxConfirmation(ctx context.Context, rpcClient *rpcclient.Client, txHash string) error {
+	for attempt := range 30 {
+		resp, err := rpcClient.GetTransaction(ctx, protocol.GetTransactionRequest{Hash: txHash})
+		if err != nil {
+			return fmt.Errorf("getTransaction failed for %s: %v", txHash, err)
+		}
+		switch resp.Status {
+		case protocol.TransactionStatusSuccess:
+			return nil
+		case protocol.TransactionStatusFailed:
+			return fmt.Errorf("transaction %s failed on-chain", txHash)
+		}
+		if attempt == 29 {
+			return fmt.Errorf("transaction %s not confirmed after 30 attempts", txHash)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
 	return nil
 }
 
-func (w *WorkerAccount) GetAccountBalance(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
+func (w *WorkerAccount) GetOnChainBalance(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
 	accountID, err := xdr.AddressToAccountId(w.Keypair.Address())
 	if err != nil {
 		return 0, fmt.Errorf("failed to convert address to account ID: %v", err)
@@ -63,13 +140,14 @@ func (w *WorkerAccount) GetAccountBalance(ctx context.Context, rpcClient *rpccli
 	if err := xdr.SafeUnmarshalBase64(resp.Entries[0].DataXDR, &entry); err != nil {
 		return 0, fmt.Errorf("failed to unmarshal ledger entry data: %v", err)
 	}
-	return int64(entry.Account.Balance), nil // balance in stroops (1 XLM = 10^7 stroops)
+	xlmBalance := entry.Account.Balance / util.StroopsPerXLM
+
+	return int64(xlmBalance), nil // balance in stroops (1 XLM = 10^7 stroops)
 }
 
-func (w *WorkerAccount) getAccountSeq(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
-	if seq := w.Id.Load(); seq > 0 {
-		return seq, nil
-	}
+// fetchOnChainSeq always fetches the current sequence from the network.
+// Used by setup/teardown operations that need the true on-chain state.
+func (w *WorkerAccount) fetchOnChainSeq(ctx context.Context, rpcClient *rpcclient.Client) (int64, error) {
 	accountDetail, err := rpcClient.LoadAccount(ctx, w.Keypair.Address())
 	if err != nil {
 		return 0, fmt.Errorf("failed to get account detail for %s: %v", w.Keypair.Address(), err)
@@ -95,26 +173,74 @@ func (w *WorkerAccount) fundTestnetAccount(friendbotURL string) error {
 	return nil
 }
 
-func VerifyOnChainAndStore(ctx context.Context, rpcClient *rpcclient.Client, accounts []*WorkerAccount) (bool, error) {
+// Verify an account's sequence number is correctly stored on chain and store it in the account struct
+// Retries for up to ~30 seconds total since there may be some delay between funding tx confirmation and account visibility on-chain
+func VerifyOnChainSeqAndStore(ctx context.Context, rpcClient *rpcclient.Client, accounts []*WorkerAccount) error {
+	var lastErr error
 	for attempt := range 10 {
-		var err error
 		allFound := true
 		for _, acct := range accounts {
-			if seq, err := acct.getAccountSeq(ctx, rpcClient); err != nil || seq <= 0 {
+			seq, err := acct.fetchOnChainSeq(ctx, rpcClient)
+			if err != nil || seq <= 0 {
 				allFound = false
+				lastErr = err
 				continue
-			} else {
-				acct.Id.Store(seq)
 			}
+			acct.Id.Store(seq)
 		}
 		if allFound {
-			break
+			return nil
 		}
 		if attempt == 9 {
-			return false, fmt.Errorf("some accounts not visible on-chain after funding: %v", err)
+			return fmt.Errorf("some accounts not visible on-chain after funding: %v", lastErr)
 		}
-		time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 500 * time.Millisecond):
+		}
 	}
 
-	return true, nil
+	return nil
+}
+
+// Verify all account's balances are correct on chain and stores the balance in each account struct
+// Retries for up to ~30 seconds total to account for any possible delays
+func VerifyOnChainBalanceAndStore(
+	ctx context.Context,
+	rpcClient *rpcclient.Client,
+	accounts []*WorkerAccount,
+	expectedBalance int64,
+) error {
+	var lastErr error
+	for attempt := range 10 {
+		allFound := true
+		for _, acct := range accounts {
+			balance, err := acct.GetOnChainBalance(ctx, rpcClient)
+			if err != nil {
+				allFound = false
+				lastErr = err
+				continue
+			}
+			if balance != expectedBalance {
+				allFound = false
+				lastErr = fmt.Errorf("unexpected balance for worker account %s: got %d, expected %d",
+					acct.Keypair.Address(), balance, expectedBalance)
+				continue
+			}
+			acct.Balance.Store(balance)
+		}
+		if allFound {
+			return nil
+		}
+		if attempt == 9 {
+			return fmt.Errorf("some accounts not visible on-chain after funding: %v", lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt+1) * 500 * time.Millisecond):
+		}
+	}
+	return nil
 }

--- a/internal/run/parameters/tx/send.go
+++ b/internal/run/parameters/tx/send.go
@@ -6,17 +6,50 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 )
 
-func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount uint64, seq int64, networkPassphrase string) (string, error) {
+func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount int64, seq int64, networkPassphrase string) (string, error) {
 	op := txnbuild.Payment{
 		Destination: to.Keypair.Address(),
 		Amount:      fmt.Sprintf("%d", amount),
 		Asset:       txnbuild.NativeAsset{},
 	}
+	return buildTxB64(&op, from, seq, networkPassphrase)
+}
+
+// BuildAccountMergeTxB64 builds a tx that closes the source account and transfers all remaining funds to the destination.
+func BuildAccountMergeTxB64(from *WorkerAccount, to *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+	op := txnbuild.AccountMerge{
+		Destination: to.Keypair.Address(),
+	}
+	return buildTxB64(&op, from, seq, networkPassphrase)
+}
+
+// BuildCreateAccountTxB64 builds a base64-encoded transaction that creates and funds a new account.
+// Used to fund worker accounts that don't yet exist on-chain.
+func BuildCreateAccountTxB64(
+	from *WorkerAccount,
+	to *WorkerAccount,
+	amount int64,
+	seq int64,
+	networkPassphrase string,
+) (string, error) {
+	op := txnbuild.CreateAccount{
+		Destination: to.Keypair.Address(),
+		Amount:      fmt.Sprintf("%d", amount),
+	}
+	return buildTxB64(&op, from, seq, networkPassphrase)
+}
+
+// BuildSelfSendTxB64 builds a base64-encoded transaction for a 1 XLM self-payment used for sendTransaction calls.
+func BuildSelfSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+	return BuildSendPaymentTxB64(acct, acct, 1, seq, networkPassphrase)
+}
+
+func buildTxB64(op txnbuild.Operation, from *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
 	sa := txnbuild.NewSimpleAccount(from.Keypair.Address(), seq)
 	txn, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &sa,
 		IncrementSequenceNum: true,
-		Operations:           []txnbuild.Operation{&op},
+		Operations:           []txnbuild.Operation{op},
 		BaseFee:              txnbuild.MinBaseFee,
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
 	})
@@ -24,15 +57,9 @@ func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount uint64
 		return "", fmt.Errorf("couldn't create transaction: %w", err)
 	}
 
-	// sign with from.Keypair, return txn.Base64()
 	txn, err = txn.Sign(networkPassphrase, from.Keypair)
 	if err != nil {
 		return "", fmt.Errorf("couldn't sign transaction: %w", err)
 	}
 	return txn.Base64()
-}
-
-// BuildSelfSendTxB64 builds a signed base64-encoded transaction for a self-payment used for sendTransaction calls.
-func BuildSelfSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
-	return BuildSendPaymentTxB64(acct, acct, 1, seq, networkPassphrase)
 }

--- a/internal/run/parameters/tx/send.go
+++ b/internal/run/parameters/tx/send.go
@@ -6,32 +6,32 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 )
 
-func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount int64, seq int64, networkPassphrase string) (string, error) {
+func BuildSendPaymentTx(from *WorkerAccount, to *WorkerAccount, amount int64, seq int64, networkPassphrase string) (*txnbuild.Transaction, error) {
 	op := txnbuild.Payment{
 		Destination: to.Keypair.Address(),
 		Amount:      fmt.Sprintf("%d", amount),
 		Asset:       txnbuild.NativeAsset{},
 	}
-	return buildTxB64([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
+	return buildTx([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
 }
 
-// BuildAccountMergeTxB64 builds a tx that closes the source account and transfers all remaining funds to the destination.
-func BuildAccountMergeTxB64(from *WorkerAccount, to *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+// BuildAccountMergeTx builds a tx that closes the source account and transfers all remaining funds to the destination.
+func BuildAccountMergeTx(from *WorkerAccount, to *WorkerAccount, seq int64, networkPassphrase string) (*txnbuild.Transaction, error) {
 	op := txnbuild.AccountMerge{
 		Destination: to.Keypair.Address(),
 	}
-	return buildTxB64([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
+	return buildTx([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
 }
 
-// BuildCreateAccountTxB64 builds a base64-encoded transaction that creates and funds new accounts.
+// BuildCreateAccountsTx builds a transaction that creates and funds new accounts.
 // Used to fund worker accounts that don't yet exist on-chain.
-func BuildCreateAccountsTxB64(
+func BuildCreateAccountsTx(
 	from *WorkerAccount,
 	to []*WorkerAccount,
 	amount int64,
 	seq int64,
 	networkPassphrase string,
-) (string, error) {
+) (*txnbuild.Transaction, error) {
 	ops := make([]txnbuild.Operation, 0, len(to))
 	for _, acct := range to {
 		op := txnbuild.CreateAccount{
@@ -40,20 +40,28 @@ func BuildCreateAccountsTxB64(
 		}
 		ops = append(ops, &op)
 	}
-	return buildTxB64(ops, from, seq, networkPassphrase)
+	return buildTx(ops, from, seq, networkPassphrase)
+}
+
+func BuildSelfSendTx(acct *WorkerAccount, seq int64, networkPassphrase string) (*txnbuild.Transaction, error) {
+	return BuildSendPaymentTx(acct, acct, 1, seq, networkPassphrase)
 }
 
 // BuildSelfSendTxB64 builds a base64-encoded transaction for a 1 XLM self-payment used for sendTransaction calls.
 func BuildSelfSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
-	return BuildSendPaymentTxB64(acct, acct, 1, seq, networkPassphrase)
+	txn, err := BuildSelfSendTx(acct, seq, networkPassphrase)
+	if err != nil {
+		return "", err
+	}
+	return txn.Base64()
 }
 
-func buildTxB64(
+func buildTx(
 	ops []txnbuild.Operation,
 	from *WorkerAccount,
 	seq int64,
 	networkPassphrase string,
-) (string, error) {
+) (*txnbuild.Transaction, error) {
 	sa := txnbuild.NewSimpleAccount(from.Keypair.Address(), seq)
 	txn, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &sa,
@@ -63,12 +71,12 @@ func buildTxB64(
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
 	})
 	if err != nil {
-		return "", fmt.Errorf("couldn't create transaction: %w", err)
+		return nil, fmt.Errorf("couldn't create transaction: %w", err)
 	}
 
 	txn, err = txn.Sign(networkPassphrase, from.Keypair)
 	if err != nil {
-		return "", fmt.Errorf("couldn't sign transaction: %w", err)
+		return nil, fmt.Errorf("couldn't sign transaction: %w", err)
 	}
-	return txn.Base64()
+	return txn, nil
 }

--- a/internal/run/parameters/tx/send.go
+++ b/internal/run/parameters/tx/send.go
@@ -12,7 +12,7 @@ func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount int64,
 		Amount:      fmt.Sprintf("%d", amount),
 		Asset:       txnbuild.NativeAsset{},
 	}
-	return buildTxB64(&op, from, seq, networkPassphrase)
+	return buildTxB64([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
 }
 
 // BuildAccountMergeTxB64 builds a tx that closes the source account and transfers all remaining funds to the destination.
@@ -20,23 +20,27 @@ func BuildAccountMergeTxB64(from *WorkerAccount, to *WorkerAccount, seq int64, n
 	op := txnbuild.AccountMerge{
 		Destination: to.Keypair.Address(),
 	}
-	return buildTxB64(&op, from, seq, networkPassphrase)
+	return buildTxB64([]txnbuild.Operation{&op}, from, seq, networkPassphrase)
 }
 
-// BuildCreateAccountTxB64 builds a base64-encoded transaction that creates and funds a new account.
+// BuildCreateAccountTxB64 builds a base64-encoded transaction that creates and funds new accounts.
 // Used to fund worker accounts that don't yet exist on-chain.
-func BuildCreateAccountTxB64(
+func BuildCreateAccountsTxB64(
 	from *WorkerAccount,
-	to *WorkerAccount,
+	to []*WorkerAccount,
 	amount int64,
 	seq int64,
 	networkPassphrase string,
 ) (string, error) {
-	op := txnbuild.CreateAccount{
-		Destination: to.Keypair.Address(),
-		Amount:      fmt.Sprintf("%d", amount),
+	ops := make([]txnbuild.Operation, 0, len(to))
+	for _, acct := range to {
+		op := txnbuild.CreateAccount{
+			Destination: acct.Keypair.Address(),
+			Amount:      fmt.Sprintf("%d", amount),
+		}
+		ops = append(ops, &op)
 	}
-	return buildTxB64(&op, from, seq, networkPassphrase)
+	return buildTxB64(ops, from, seq, networkPassphrase)
 }
 
 // BuildSelfSendTxB64 builds a base64-encoded transaction for a 1 XLM self-payment used for sendTransaction calls.
@@ -44,12 +48,17 @@ func BuildSelfSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string
 	return BuildSendPaymentTxB64(acct, acct, 1, seq, networkPassphrase)
 }
 
-func buildTxB64(op txnbuild.Operation, from *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+func buildTxB64(
+	ops []txnbuild.Operation,
+	from *WorkerAccount,
+	seq int64,
+	networkPassphrase string,
+) (string, error) {
 	sa := txnbuild.NewSimpleAccount(from.Keypair.Address(), seq)
 	txn, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &sa,
 		IncrementSequenceNum: true,
-		Operations:           []txnbuild.Operation{op},
+		Operations:           ops,
 		BaseFee:              txnbuild.MinBaseFee,
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
 	})

--- a/internal/run/parameters/tx/send.go
+++ b/internal/run/parameters/tx/send.go
@@ -6,15 +6,13 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 )
 
-// BuildSendTxB64 builds a signed base64-encoded transaction for a self-payment used for sendTransaction calls.
-func BuildSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+func BuildSendPaymentTxB64(from *WorkerAccount, to *WorkerAccount, amount uint64, seq int64, networkPassphrase string) (string, error) {
 	op := txnbuild.Payment{
-		Destination: acct.Keypair.Address(), // self-payment
-		Amount:      "1",
+		Destination: to.Keypair.Address(),
+		Amount:      fmt.Sprintf("%d", amount),
 		Asset:       txnbuild.NativeAsset{},
 	}
-
-	sa := txnbuild.NewSimpleAccount(acct.Keypair.Address(), seq)
+	sa := txnbuild.NewSimpleAccount(from.Keypair.Address(), seq)
 	txn, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &sa,
 		IncrementSequenceNum: true,
@@ -26,10 +24,15 @@ func BuildSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (s
 		return "", fmt.Errorf("couldn't create transaction: %w", err)
 	}
 
-	// sign with acct.Keypair, return txn.Base64()
-	txn, err = txn.Sign(networkPassphrase, acct.Keypair)
+	// sign with from.Keypair, return txn.Base64()
+	txn, err = txn.Sign(networkPassphrase, from.Keypair)
 	if err != nil {
 		return "", fmt.Errorf("couldn't sign transaction: %w", err)
 	}
 	return txn.Base64()
+}
+
+// BuildSelfSendTxB64 builds a signed base64-encoded transaction for a self-payment used for sendTransaction calls.
+func BuildSelfSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+	return BuildSendPaymentTxB64(acct, acct, 1, seq, networkPassphrase)
 }

--- a/internal/run/parameters/tx/send.go
+++ b/internal/run/parameters/tx/send.go
@@ -1,0 +1,35 @@
+package tx
+
+import (
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/txnbuild"
+)
+
+// BuildSendTxB64 builds a signed base64-encoded transaction for a self-payment used for sendTransaction calls.
+func BuildSendTxB64(acct *WorkerAccount, seq int64, networkPassphrase string) (string, error) {
+	op := txnbuild.Payment{
+		Destination: acct.Keypair.Address(), // self-payment
+		Amount:      "1",
+		Asset:       txnbuild.NativeAsset{},
+	}
+
+	sa := txnbuild.NewSimpleAccount(acct.Keypair.Address(), seq)
+	txn, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &sa,
+		IncrementSequenceNum: true,
+		Operations:           []txnbuild.Operation{&op},
+		BaseFee:              txnbuild.MinBaseFee,
+		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewInfiniteTimeout()},
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't create transaction: %w", err)
+	}
+
+	// sign with acct.Keypair, return txn.Base64()
+	txn, err = txn.Sign(networkPassphrase, acct.Keypair)
+	if err != nil {
+		return "", fmt.Errorf("couldn't sign transaction: %w", err)
+	}
+	return txn.Base64()
+}

--- a/internal/run/parameters/tx/simulate.go
+++ b/internal/run/parameters/tx/simulate.go
@@ -8,26 +8,44 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-// BuildSimulateTxB64 takes a contract ID and builds a base64-encoded transaction envelope
-// used for simulateTransaction calls targeting that contract.
-func BuildSimulateTxB64(contractStrkey string) (string, error) {
-	contractID, err := decodeContractID(contractStrkey)
-	if err != nil {
-		return "", err
-	}
-
+// BuildSimulateTxB64 builds a base64-encoded transaction envelope used for simulateTransaction calls.
+// Uses zero contract/source accounts — no real accounts needed since this is never submitted on-chain.
+func BuildSimulateTxB64() (string, error) {
+	var contractID xdr.ContractId // 32 zero bytes
 	contractAddr := xdr.ScAddress{
 		Type:       xdr.ScAddressTypeScAddressTypeContract,
 		ContractId: &contractID,
 	}
 
-	op := txnbuild.InvokeHostFunction{
+	op := BuildInvokeHostFunction(contractAddr, xdr.ScSymbol("transfer"), xdr.ScVec{})
+
+	sa := txnbuild.NewSimpleAccount(strkey.MustEncode(strkey.VersionByteAccountID, make([]byte, 32)), 0)
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &sa,
+		IncrementSequenceNum: false,
+		Operations:           []txnbuild.Operation{&op},
+		BaseFee:              txnbuild.MinBaseFee,
+		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimebounds(0, 0)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't build simulate tx: %w", err)
+	}
+	return tx.Base64()
+}
+
+// Build a simple InvokeHostFunction tx touching contract storage and erroring only at execution
+func BuildInvokeHostFunction(
+	contractAddr xdr.ScAddress,
+	functionName xdr.ScSymbol,
+	args []xdr.ScVal,
+) txnbuild.InvokeHostFunction {
+	return txnbuild.InvokeHostFunction{
 		HostFunction: xdr.HostFunction{
 			Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
 			InvokeContract: &xdr.InvokeContractArgs{
 				ContractAddress: contractAddr,
-				FunctionName:    "transfer", // arbitrary; WASM errors at runtime, not before
-				Args:            xdr.ScVec{},
+				FunctionName:    functionName,
+				Args:            xdr.ScVec(args),
 			},
 		},
 		Ext: xdr.TransactionExt{
@@ -52,32 +70,4 @@ func BuildSimulateTxB64(contractStrkey string) (string, error) {
 			},
 		},
 	}
-
-	source := zeroAccountID()
-	sa := txnbuild.NewSimpleAccount(source, 0)
-	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
-		SourceAccount:        &sa,
-		IncrementSequenceNum: false,
-		Operations:           []txnbuild.Operation{&op},
-		BaseFee:              txnbuild.MinBaseFee,
-		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimebounds(0, 0)},
-	})
-	if err != nil {
-		return "", fmt.Errorf("couldn't build simulate tx for %s: %w", contractStrkey, err)
-	}
-	return tx.Base64()
-}
-
-func decodeContractID(contractStrkey string) (xdr.ContractId, error) {
-	decoded, err := strkey.Decode(strkey.VersionByteContract, contractStrkey)
-	if err != nil {
-		return xdr.ContractId{}, fmt.Errorf("invalid contract strkey %q: %w", contractStrkey, err)
-	}
-	var id xdr.ContractId
-	copy(id[:], decoded)
-	return id, nil
-}
-
-func zeroAccountID() string {
-	return strkey.MustEncode(strkey.VersionByteAccountID, make([]byte, 32))
 }

--- a/internal/run/parameters/tx/simulate.go
+++ b/internal/run/parameters/tx/simulate.go
@@ -8,18 +8,35 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
-// BuildSimulateTxB64 builds a base64-encoded transaction envelope used for simulateTransaction calls.
-// Uses zero contract/source accounts — no real accounts needed since this is never submitted on-chain.
-func BuildSimulateTxB64() (string, error) {
-	var contractID xdr.ContractId // 32 zero bytes
-	contractAddr := xdr.ScAddress{
-		Type:       xdr.ScAddressTypeScAddressTypeContract,
-		ContractId: &contractID,
+// BuildSimulateTxB64 builds a base64-encoded PaymentToContract used for simulateTransaction calls.
+// Uses zero contract/source accounts - no real accounts needed since this is never submitted on-chain.
+func BuildSimulateTxB64(networkPassphrase string) (string, error) {
+	var (
+		contractId      xdr.ContractId
+		sourceAccountId string
+		destId          string
+		err             error
+	)
+	if sourceAccountId, err = strkey.Encode(strkey.VersionByteAccountID, make([]byte, 32)); err != nil {
+		return "", fmt.Errorf("couldn't encode source account ID: %w", err)
+	}
+	if destId, err = strkey.Encode(strkey.VersionByteContract, contractId[:]); err != nil {
+		return "", fmt.Errorf("couldn't encode destination ID: %w", err)
 	}
 
-	op := BuildInvokeHostFunction(contractAddr, xdr.ScSymbol("transfer"), xdr.ScVec{})
+	op, err := txnbuild.NewPaymentToContract(txnbuild.PaymentToContractParams{
+		NetworkPassphrase: networkPassphrase,
+		Destination:       destId,
+		Amount:            "10",
+		Asset:             txnbuild.NativeAsset{},
+		SourceAccount:     sourceAccountId,
+		Fees:              nil, // use default fees
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't build payment to contract op: %w", err)
+	}
 
-	sa := txnbuild.NewSimpleAccount(strkey.MustEncode(strkey.VersionByteAccountID, make([]byte, 32)), 0)
+	sa := txnbuild.NewSimpleAccount(sourceAccountId, 0)
 	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
 		SourceAccount:        &sa,
 		IncrementSequenceNum: false,
@@ -31,43 +48,4 @@ func BuildSimulateTxB64() (string, error) {
 		return "", fmt.Errorf("couldn't build simulate tx: %w", err)
 	}
 	return tx.Base64()
-}
-
-// Build a simple InvokeHostFunction tx touching contract storage and erroring only at execution
-func BuildInvokeHostFunction(
-	contractAddr xdr.ScAddress,
-	functionName xdr.ScSymbol,
-	args []xdr.ScVal,
-) txnbuild.InvokeHostFunction {
-	return txnbuild.InvokeHostFunction{
-		HostFunction: xdr.HostFunction{
-			Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
-			InvokeContract: &xdr.InvokeContractArgs{
-				ContractAddress: contractAddr,
-				FunctionName:    functionName,
-				Args:            xdr.ScVec(args),
-			},
-		},
-		Ext: xdr.TransactionExt{
-			V: 1,
-			SorobanData: &xdr.SorobanTransactionData{
-				Resources: xdr.SorobanResources{
-					Footprint: xdr.LedgerFootprint{
-						ReadOnly: []xdr.LedgerKey{{
-							Type: xdr.LedgerEntryTypeContractData,
-							ContractData: &xdr.LedgerKeyContractData{
-								Contract:   contractAddr,
-								Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
-								Durability: xdr.ContractDataDurabilityPersistent,
-							},
-						}},
-					},
-					Instructions:  500_000,
-					DiskReadBytes: 2_000,
-					WriteBytes:    0,
-				},
-				ResourceFee: 10_000_000,
-			},
-		},
-	}
 }

--- a/internal/run/parameters/tx/simulate.go
+++ b/internal/run/parameters/tx/simulate.go
@@ -1,0 +1,83 @@
+package tx
+
+import (
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/strkey"
+	"github.com/stellar/go-stellar-sdk/txnbuild"
+	"github.com/stellar/go-stellar-sdk/xdr"
+)
+
+// BuildSimulateTxB64 takes a contract ID and builds a base64-encoded transaction envelope
+// used for simulateTransaction calls targeting that contract.
+func BuildSimulateTxB64(contractStrkey string) (string, error) {
+	contractID, err := decodeContractID(contractStrkey)
+	if err != nil {
+		return "", err
+	}
+
+	contractAddr := xdr.ScAddress{
+		Type:       xdr.ScAddressTypeScAddressTypeContract,
+		ContractId: &contractID,
+	}
+
+	op := txnbuild.InvokeHostFunction{
+		HostFunction: xdr.HostFunction{
+			Type: xdr.HostFunctionTypeHostFunctionTypeInvokeContract,
+			InvokeContract: &xdr.InvokeContractArgs{
+				ContractAddress: contractAddr,
+				FunctionName:    "transfer", // arbitrary; WASM errors at runtime, not before
+				Args:            xdr.ScVec{},
+			},
+		},
+		Ext: xdr.TransactionExt{
+			V: 1,
+			SorobanData: &xdr.SorobanTransactionData{
+				Resources: xdr.SorobanResources{
+					Footprint: xdr.LedgerFootprint{
+						ReadOnly: []xdr.LedgerKey{{
+							Type: xdr.LedgerEntryTypeContractData,
+							ContractData: &xdr.LedgerKeyContractData{
+								Contract:   contractAddr,
+								Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+								Durability: xdr.ContractDataDurabilityPersistent,
+							},
+						}},
+					},
+					Instructions:  500_000,
+					DiskReadBytes: 2_000,
+					WriteBytes:    0,
+				},
+				ResourceFee: 10_000_000,
+			},
+		},
+	}
+
+	source := zeroAccountID()
+	sa := txnbuild.NewSimpleAccount(source, 0)
+	tx, err := txnbuild.NewTransaction(txnbuild.TransactionParams{
+		SourceAccount:        &sa,
+		IncrementSequenceNum: false,
+		Operations:           []txnbuild.Operation{&op},
+		BaseFee:              txnbuild.MinBaseFee,
+		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimebounds(0, 0)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't build simulate tx for %s: %w", contractStrkey, err)
+	}
+	return tx.Base64()
+}
+
+func decodeContractID(contractStrkey string) (xdr.ContractId, error) {
+	decoded, err := strkey.Decode(strkey.VersionByteContract, contractStrkey)
+	if err != nil {
+		return xdr.ContractId{}, fmt.Errorf("invalid contract strkey %q: %w", contractStrkey, err)
+	}
+	var id xdr.ContractId
+	copy(id[:], decoded)
+	return id, nil
+}
+
+func zeroAccountID() string {
+	return strkey.MustEncode(strkey.VersionByteAccountID, make([]byte, 32))
+}

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
@@ -66,11 +67,10 @@ func NewAccountPool(
 	}
 	pool.PoolBalance = originAccountBalance
 
-	// Reserve 100 XLM in the origin account for base reserve + tx fees
-	spendable := originAccountBalance - 100
-	budgetPerWorker := spendable / int64(numAccounts)
-	if budgetPerWorker <= util.MinimumWorkerBalance {
-		return nil, fmt.Errorf("origin account does not have enough balance to fund workers")
+	budgetPerWorker := int64(util.MinimumWorkerBalance)
+	// Reserve 100 XLM in the origin account so it can remain the sole fee payer throughout the run.
+	if budgetPerWorker*int64(numAccounts) > originAccountBalance-100 {
+		return nil, fmt.Errorf("origin account does not have enough balance to minimally fund workers and pay fees")
 	}
 
 	// Fund worker accounts to ensure they have enough balance for the test
@@ -87,7 +87,7 @@ func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, lo
 	// Each worker is a separate source account so there are no sequence dependencies.
 	hashes := make([]string, 0, len(p.accounts))
 	for _, acct := range p.accounts {
-		hash, err := acct.MergeInto(ctx, p, p.originAccount, p.passphrase)
+		hash, err := acct.MergeInto(ctx, p, p.originAccount)
 		if err != nil {
 			logger.Errorf("failed to merge worker account %s: %v", acct.Keypair.Address(), err)
 			continue
@@ -104,9 +104,12 @@ func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, lo
 	balance, err := p.originAccount.GetOnChainBalance(ctx, rpcClient)
 	if err != nil {
 		logger.Errorf("balance verification failed after merging worker accounts back into origin account: %v", err)
-	} else if balance < p.PoolBalance-util.FeeTolerance {
-		logger.Errorf("balance verification failed after consolidating accounts: expected %d, got %d",
+	} else if balance > p.PoolBalance {
+		logger.Warnf("origin balance increased unexpectedly after consolidation: started %d, ended %d",
 			p.PoolBalance, balance)
+	} else {
+		logger.Infof("Origin account balance after consolidation: %d (approximately %d XLM spent on setup, load, and cleanup fees)",
+			balance, p.PoolBalance-balance)
 	}
 
 	logger.Infof("Successfully merged %d worker accounts back into origin account", len(hashes))
@@ -211,4 +214,23 @@ func (p *AccountPool) Next() (*WorkerAccount, int64) {
 	acct := p.accounts[i%int64(len(p.accounts))]
 	p.idx++
 	return acct, acct.Id.Add(1) - 1
+}
+
+// WrapWithOriginFeeBumpB64 wraps a signed inner transaction so the origin account pays the fee.
+func (p *AccountPool) WrapWithOriginFeeBumpB64(innerTx *txnbuild.Transaction) (string, error) {
+	feeBumpTx, err := txnbuild.NewFeeBumpTransaction(txnbuild.FeeBumpTransactionParams{
+		Inner:      innerTx,
+		FeeAccount: p.originAccount.Keypair.Address(),
+		BaseFee:    innerTx.BaseFee(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("couldn't create fee bump transaction: %w", err)
+	}
+
+	feeBumpTx, err = feeBumpTx.Sign(p.passphrase, p.originAccount.Keypair)
+	if err != nil {
+		return "", fmt.Errorf("couldn't sign fee bump transaction: %w", err)
+	}
+
+	return feeBumpTx.Base64()
 }

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -7,34 +7,61 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
 type AccountPool struct {
-	rpcClient     *rpcclient.Client
-	passphrase    string
+	rpcClient    *rpcclient.Client
+	passphrase   string
+	friendbotURL string
+
+	PoolBalance   int64          // track total balance across all accounts in the pool for verification at the end of the test
 	originAccount *WorkerAccount // account that funds the worker accounts
 	accounts      []*WorkerAccount
 	idx           int64 // atomically incr index to rotate through accounts
-	mu            sync.Mutex
+
+	mu sync.Mutex
 }
 
 // Makes a pool of workers and funds each of them with testnet friendbot XLM
 func NewTestnetAccountPool(
 	ctx context.Context,
 	rpcClient *rpcclient.Client,
+	originAccountKp *keypair.Full, // optional param to specify funding account
 	numAccounts uint32,
 ) (*AccountPool, error) {
 	pool := &AccountPool{
 		rpcClient: rpcClient,
 	}
-	originAccount, err := pool.NewTestnetOriginAccount(ctx)
+	getNetworkResponse, err := pool.rpcClient.GetNetwork(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get network info: %v", err)
+	}
+	pool.friendbotURL = getNetworkResponse.FriendbotURL
+	pool.passphrase = getNetworkResponse.Passphrase
+
+	originAccount, err := pool.NewTestnetOriginAccount(ctx, originAccountKp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create and fund origin account: %v", err)
 	}
 	pool.originAccount = originAccount
 
-	// Fund worker accounts with 10k XLM each to ensure they have enough balance for the test
-	accounts, err := pool.FundWorkers(ctx, 10000, numAccounts)
+	originAccountBalance, err := originAccount.GetOnChainBalance(ctx, rpcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get balance for origin account: %v", err)
+	}
+	pool.PoolBalance = originAccountBalance
+
+	// Reserve 100 XLM in the origin account for base reserve + tx fees
+	spendable := originAccountBalance - 100
+	budgetPerWorker := spendable / int64(numAccounts)
+	if budgetPerWorker <= util.MinimumWorkerBalance {
+		return nil, fmt.Errorf("origin account does not have enough balance to fund workers")
+	}
+
+	// Fund worker accounts to ensure they have enough balance for the test
+	accounts, err := pool.FundWorkers(ctx, budgetPerWorker, numAccounts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fund worker accounts: %v", err)
 	}
@@ -42,18 +69,45 @@ func NewTestnetAccountPool(
 	return pool, nil
 }
 
-func (p *AccountPool) Close() {
-	// direct all funds from worker accounts back to origin account
+func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, logger *log.Entry) error {
+	// Submit all merge txs first, then confirm all at once.
+	// Each worker is a separate source account so there are no sequence dependencies.
+	hashes := make([]string, 0, len(p.accounts))
+	for _, acct := range p.accounts {
+		hash, err := acct.MergeInto(ctx, p, p.originAccount, p.passphrase)
+		if err != nil {
+			logger.Errorf("failed to merge worker account %s: %v", acct.Keypair.Address(), err)
+			continue
+		}
+		hashes = append(hashes, hash)
+	}
+
+	// Await all merge confirmations
+	for _, hash := range hashes {
+		if err := awaitTxConfirmation(ctx, p.rpcClient, hash); err != nil {
+			logger.Errorf("failed to confirm merge tx %s: %v", hash, err)
+		}
+	}
+	balance, err := p.originAccount.GetOnChainBalance(ctx, rpcClient)
+	if err != nil {
+		logger.Errorf("balance verification failed after merging worker accounts back into origin account: %v", err)
+	} else if balance < p.PoolBalance-util.FeeTolerance {
+		logger.Errorf("balance verification failed after consolidating accounts: expected %d, got %d",
+			p.PoolBalance, balance)
+	}
+
+	logger.Infof("Successfully merged %d worker accounts back into origin account", len(hashes))
+	return nil
 }
 
 // Creates and funds all workers in the pool with the specified amount from the origin account
-func (p *AccountPool) FundWorkers(ctx context.Context, amountPerWorker uint64, numWorkers uint32) ([]*WorkerAccount, error) {
-	if amountPerWorker*uint64(numWorkers) > p.originAccount.Balance.Load() {
+func (p *AccountPool) FundWorkers(ctx context.Context, budgetPerWorker int64, numWorkers uint32) ([]*WorkerAccount, error) {
+	if budgetPerWorker*int64(numWorkers) > p.originAccount.Balance.Load() {
 		return nil, fmt.Errorf("origin account does not have enough balance to fund workers")
 	}
 	sa := p.originAccount
 	accounts := make([]*WorkerAccount, numWorkers)
-	// For each worker account, send a payment from the origin account to fund it
+	// Submit and confirm each CreateAccount tx one at a time
 	for i := range accounts {
 		workerKp, err := keypair.Random()
 		if err != nil {
@@ -61,39 +115,59 @@ func (p *AccountPool) FundWorkers(ctx context.Context, amountPerWorker uint64, n
 		}
 		accounts[i] = &WorkerAccount{Keypair: workerKp}
 
-		if err := sa.SendPaymentTo(ctx, p, accounts[i], amountPerWorker, p.passphrase); err != nil {
+		hash, err := sa.CreateAccountFor(
+			ctx,
+			p,
+			accounts[i],
+			budgetPerWorker,
+			p.passphrase,
+		)
+		if err != nil {
 			return nil, fmt.Errorf("failed to fund worker account %s: %v", workerKp.Address(), err)
 		}
+		if err := awaitTxConfirmation(ctx, p.rpcClient, hash); err != nil {
+			return nil, fmt.Errorf("failed to confirm funding tx for %s: %v", workerKp.Address(), err)
+		}
 	}
-	// Wait for ledger close so all accounts visible on-chain, then fetch all sequence numbers
-	if ok, err := VerifyOnChainAndStore(ctx, p.rpcClient, accounts); err != nil || !ok {
+	// Fetch and store sequence numbers for all accounts
+	if err := VerifyOnChainSeqAndStore(ctx, p.rpcClient, accounts); err != nil {
 		return nil, fmt.Errorf("failed to verify accounts on-chain: %v", err)
+	}
+
+	// Verify all accounts have the correct balance on chain and store the balance in each account struct
+	// Serves as a final check that all funding transactions were successful and the accounts are ready to use
+	if err := VerifyOnChainBalanceAndStore(ctx, p.rpcClient, accounts, budgetPerWorker); err != nil {
+		return nil, fmt.Errorf("failed to verify balance for worker accounts: %v", err)
 	}
 
 	return accounts, nil
 }
 
 // Creates a new origin account using friendbot
-func (p *AccountPool) NewTestnetOriginAccount(ctx context.Context) (*WorkerAccount, error) {
-	friendbotUrlReq, err := p.rpcClient.GetNetwork(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get friendbot URL: %v", err)
-	} else if friendbotUrlReq.FriendbotURL == "" {
-		return nil, fmt.Errorf("network does not have friendbot URL (check RPC config?)")
+func (p *AccountPool) NewTestnetOriginAccount(ctx context.Context, originAccountKp *keypair.Full) (*WorkerAccount, error) {
+	acct := &WorkerAccount{}
+	if originAccountKp != nil {
+		acct = &WorkerAccount{Keypair: originAccountKp}
+	} else {
+		kp, err := keypair.Random()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
+		}
+		acct = &WorkerAccount{Keypair: kp}
+		if err := acct.fundTestnetAccount(p.friendbotURL); err != nil {
+			return nil, fmt.Errorf("failed to fund origin account %s: %v", kp.Address(), err)
+		}
 	}
 
-	kp, err := keypair.Random()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate random keypair: %v", err)
-	}
-	acct := &WorkerAccount{Keypair: kp}
-	if err := acct.fundTestnetAccount(friendbotUrlReq.FriendbotURL); err != nil {
-		return nil, fmt.Errorf("failed to fund origin account %s: %v", kp.Address(), err)
-	}
-
-	if ok, err := VerifyOnChainAndStore(ctx, p.rpcClient, []*WorkerAccount{acct}); err != nil || !ok {
+	if err := VerifyOnChainSeqAndStore(ctx, p.rpcClient, []*WorkerAccount{acct}); err != nil {
 		return nil, fmt.Errorf("failed to verify origin account on-chain: %v", err)
 	}
+
+	balance, err := acct.GetOnChainBalance(ctx, p.rpcClient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get balance for origin account %s: %v", acct.Keypair.Address(), err)
+	}
+	acct.Balance.Store(balance)
 
 	return acct, nil
 }

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -124,26 +124,32 @@ func (p *AccountPool) FundWorkers(
 	}
 	sa := p.originAccount
 	accounts := make([]*WorkerAccount, numWorkers)
-	// Submit and confirm each CreateAccount tx one at a time
 	for i := range accounts {
 		workerKp, err := keypair.Random()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
 		}
 		accounts[i] = &WorkerAccount{Keypair: workerKp}
+	}
 
-		hash, err := sa.CreateAccountFor(
+	// Create worker accounts in batches
+	for start := 0; start < len(accounts); start += util.MaxCreateAccountsPerTx {
+		end := start + util.MaxCreateAccountsPerTx
+		end = min(end, len(accounts))
+		batch := accounts[start:end]
+
+		hash, err := sa.CreateAccountsFor(
 			ctx,
 			p,
-			accounts[i],
+			batch,
 			budgetPerWorker,
 			p.passphrase,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fund worker account %s: %v", workerKp.Address(), err)
+			return nil, fmt.Errorf("failed to fund worker accounts %d-%d: %v", start, end-1, err)
 		}
 		if err := awaitTxConfirmation(ctx, p.rpcClient, hash); err != nil {
-			return nil, fmt.Errorf("failed to confirm funding tx for %s: %v", workerKp.Address(), err)
+			return nil, fmt.Errorf("failed to confirm funding tx for accounts %d-%d: %v", start, end-1, err)
 		}
 	}
 	// Fetch and store sequence numbers for all accounts

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -117,8 +116,7 @@ func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, lo
 		}
 
 		logger.Warnf("Retrying merge for %d worker accounts after attempt %d", len(p.accounts), attempt)
-		pauseFloat64 := math.Pow(float64(util.WorkerMergeRetryPause), float64(attempt))
-		pause := min(time.Duration(int64(pauseFloat64)), remaining)
+		pause := min(util.WorkerMergeRetryPause<<attempt, remaining)
 		if pause <= 0 {
 			continue
 		}

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -15,8 +15,9 @@ type AccountPool struct {
 	rpcClient    *rpcclient.Client
 	passphrase   string
 	friendbotURL string
+	logger       *log.Entry
 
-	PoolBalance   int64          // track total balance across all accounts in the pool for verification at the end of the test
+	PoolBalance   int64          // track total balance across all accounts in the pool for verification after test
 	originAccount *WorkerAccount // account that funds the worker accounts
 	accounts      []*WorkerAccount
 	idx           int64 // atomically incr index to rotate through accounts
@@ -27,12 +28,14 @@ type AccountPool struct {
 // Makes a pool of workers and funds each of them with testnet friendbot XLM
 func NewAccountPool(
 	ctx context.Context,
+	logger *log.Entry,
 	rpcClient *rpcclient.Client,
 	originAccountKp *keypair.Full, // optional param to specify funding account
 	numAccounts uint32,
 ) (*AccountPool, error) {
 	pool := &AccountPool{
 		rpcClient: rpcClient,
+		logger:    logger,
 	}
 	// Validate and set up network based on its type
 	getNetworkResponse, err := pool.rpcClient.GetNetwork(ctx)
@@ -111,7 +114,11 @@ func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, lo
 }
 
 // Creates and funds all workers in the pool with the specified amount from the origin account
-func (p *AccountPool) FundWorkers(ctx context.Context, budgetPerWorker int64, numWorkers uint32) ([]*WorkerAccount, error) {
+func (p *AccountPool) FundWorkers(
+	ctx context.Context,
+	budgetPerWorker int64,
+	numWorkers uint32,
+) ([]*WorkerAccount, error) {
 	if budgetPerWorker*int64(numWorkers) > p.originAccount.Balance.Load() {
 		return nil, fmt.Errorf("origin account does not have enough balance to fund workers")
 	}
@@ -154,11 +161,16 @@ func (p *AccountPool) FundWorkers(ctx context.Context, budgetPerWorker int64, nu
 }
 
 // Creates a new origin account using friendbot
-func (p *AccountPool) NewOriginAccount(ctx context.Context, originAccountKp *keypair.Full, network string) (*WorkerAccount, error) {
+func (p *AccountPool) NewOriginAccount(
+	ctx context.Context,
+	originAccountKp *keypair.Full,
+	network string,
+) (*WorkerAccount, error) {
 	acct := &WorkerAccount{}
 	if originAccountKp != nil {
 		acct = &WorkerAccount{Keypair: originAccountKp}
 	} else if network == "testnet" {
+		p.logger.Infof("No origin account provided in config, creating a new origin account for testnet...")
 		kp, err := keypair.Random()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
@@ -167,6 +179,9 @@ func (p *AccountPool) NewOriginAccount(ctx context.Context, originAccountKp *key
 		if err := acct.fundTestnetAccount(p.friendbotURL); err != nil {
 			return nil, fmt.Errorf("failed to fund origin account %s: %v", kp.Address(), err)
 		}
+		p.logger.Infof("Created + funded origin account on testnet with seed %s", kp.Seed())
+	} else {
+		return nil, fmt.Errorf("origin account keypair must be provided for %s", network)
 	}
 
 	if err := VerifyOnChainSeqAndStore(ctx, p.rpcClient, []*WorkerAccount{acct}); err != nil {

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -2,8 +2,14 @@ package tx
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
 	"sync"
+	"time"
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
@@ -11,6 +17,11 @@ import (
 	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
+
+type mergeSubmission struct {
+	account *WorkerAccount
+	hash    string
+}
 
 type AccountPool struct {
 	rpcClient    *rpcclient.Client
@@ -83,36 +94,61 @@ func NewAccountPool(
 }
 
 func (p *AccountPool) Close(ctx context.Context, rpcClient *rpcclient.Client, logger *log.Entry) error {
-	// Submit all merge txs first, then confirm all at once.
-	// Each worker is a separate source account so there are no sequence dependencies.
-	hashes := make([]string, 0, len(p.accounts))
-	for _, acct := range p.accounts {
-		hash, err := acct.MergeInto(ctx, p, p.originAccount)
-		if err != nil {
-			logger.Errorf("failed to merge worker account %s: %v", acct.Keypair.Address(), err)
+	totalAccounts := len(p.accounts)
+	deadline := time.Now().Add(util.WorkerMergeRetryWindow)
+
+	// Try merging until the deadline or all accounts are merged
+	for attempt := 0; len(p.accounts) > 0; attempt++ {
+		submissions := make([]mergeSubmission, 0, len(p.accounts))
+
+		for _, acct := range p.accounts {
+			hash, err := acct.MergeInto(ctx, p, p.originAccount)
+			if err != nil {
+				logger.Errorf("failed to submit merge for worker account %s on attempt %d: %v", acct.Keypair.Address(), attempt, err)
+				continue
+			}
+			submissions = append(submissions, mergeSubmission{account: acct, hash: hash})
+		}
+
+		awaitMergeConfirmations(ctx, p, p.rpcClient, logger, submissions, attempt)
+		remaining := time.Until(deadline)
+		if len(p.accounts) == 0 || remaining <= 0 {
+			break
+		}
+
+		logger.Warnf("Retrying merge for %d worker accounts after attempt %d", len(p.accounts), attempt)
+		pauseFloat64 := math.Pow(float64(util.WorkerMergeRetryPause), float64(attempt))
+		pause := min(time.Duration(int64(pauseFloat64)), remaining)
+		if pause <= 0 {
 			continue
 		}
-		hashes = append(hashes, hash)
-	}
-
-	// Await all merge confirmations
-	for _, hash := range hashes {
-		if err := awaitTxConfirmation(ctx, p.rpcClient, hash); err != nil {
-			logger.Errorf("failed to confirm merge tx %s: %v", hash, err)
+		select {
+		case <-ctx.Done():
+			logger.Warnf("stopping merge retries early: %v", ctx.Err())
+		case <-time.After(pause): // exponential backoff capped at remaining time until deadline
 		}
 	}
-	balance, err := p.originAccount.GetOnChainBalance(ctx, rpcClient)
-	if err != nil {
-		logger.Errorf("balance verification failed after merging worker accounts back into origin account: %v", err)
-	} else if balance > p.PoolBalance {
-		logger.Warnf("origin balance increased unexpectedly after consolidation: started %d, ended %d",
-			p.PoolBalance, balance)
-	} else {
-		logger.Infof("Origin account balance after consolidation: %d (approximately %d XLM spent on setup, load, and cleanup fees)",
-			balance, p.PoolBalance-balance)
+
+	// If we failed to merge any accounts, write their seeds to a file in ./output (safety: it's in .gitignore)
+	if len(p.accounts) > 0 {
+		if err := p.writeUnmergedWorkersJSON(util.UnmergedWorkersPath); err != nil {
+			return fmt.Errorf("failed to merge %d worker accounts after retries and failed to write %s: %w",
+				len(p.accounts), util.UnmergedWorkersPath, err)
+		}
+		logger.Errorf("Failed to merge %d worker accounts after retries; wrote seeds to %s",
+			len(p.accounts), util.UnmergedWorkersPath)
 	}
 
-	logger.Infof("Successfully merged %d worker accounts back into origin account", len(hashes))
+	if err := p.verifyOriginBalance(ctx, rpcClient); err != nil {
+		logger.Errorf("Origin account balance verification failed after merging workers: %v", err)
+	}
+
+	logger.Infof("Successfully merged %d worker accounts back into origin account",
+		totalAccounts-len(p.accounts))
+	if len(p.accounts) > 0 {
+		return fmt.Errorf("failed to merge %d worker accounts after retrying for at least %s",
+			len(p.accounts), util.WorkerMergeRetryWindow)
+	}
 	return nil
 }
 
@@ -233,4 +269,79 @@ func (p *AccountPool) WrapWithOriginFeeBumpB64(innerTx *txnbuild.Transaction) (s
 	}
 
 	return feeBumpTx.Base64()
+}
+
+func awaitMergeConfirmations(
+	ctx context.Context,
+	pool *AccountPool,
+	rpcClient *rpcclient.Client,
+	logger *log.Entry,
+	submissions []mergeSubmission,
+	attempt int,
+) {
+	if len(submissions) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for _, submission := range submissions {
+		wg.Go(func() {
+			if err := awaitTxConfirmation(ctx, rpcClient, submission.hash); err != nil {
+				logger.Errorf("failed to confirm merge tx %s for worker account %s on attempt %d: %v",
+					submission.hash, submission.account.Keypair.Address(), attempt, err)
+				return
+			}
+			pool.removeWorkerAccount(submission.account.Keypair.Address())
+		})
+	}
+	wg.Wait()
+}
+
+func (p *AccountPool) removeWorkerAccount(address string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for i, acct := range p.accounts {
+		if acct.Keypair.Address() != address {
+			continue
+		}
+		p.accounts = append(p.accounts[:i], p.accounts[i+1:]...)
+		return
+	}
+}
+
+func (p *AccountPool) writeUnmergedWorkersJSON(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create output directories for path %s: %v", path, err)
+	}
+
+	seeds := make([]string, 0, len(p.accounts))
+	for _, acct := range p.accounts {
+		seeds = append(seeds, acct.Keypair.Seed())
+	}
+	slices.Sort(seeds)
+
+	data, err := json.MarshalIndent(seeds, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal unmerged worker seeds: %v", err)
+	}
+
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("failed to write unmerged workers to %s: %v", path, err)
+	}
+
+	return nil
+}
+
+func (p *AccountPool) verifyOriginBalance(ctx context.Context, rpcClient *rpcclient.Client) error {
+	balance, err := p.originAccount.GetOnChainBalance(ctx, rpcClient)
+	if err != nil {
+		return err
+	}
+	if balance > p.PoolBalance {
+		return fmt.Errorf("origin balance increased unexpectedly after consolidation: started %d, ended %d",
+			p.PoolBalance, balance)
+	}
+	return fmt.Errorf("Origin account balance after consolidation: %d (approximately %d XLM spent on fees)",
+		balance, p.PoolBalance-balance)
 }

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -1,0 +1,109 @@
+package tx
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	"github.com/stellar/go-stellar-sdk/keypair"
+)
+
+type AccountPool struct {
+	rpcClient     *rpcclient.Client
+	passphrase    string
+	originAccount *WorkerAccount // account that funds the worker accounts
+	accounts      []*WorkerAccount
+	idx           int64 // atomically incr index to rotate through accounts
+	mu            sync.Mutex
+}
+
+// Makes a pool of workers and funds each of them with testnet friendbot XLM
+func NewTestnetAccountPool(
+	ctx context.Context,
+	rpcClient *rpcclient.Client,
+	numAccounts uint32,
+) (*AccountPool, error) {
+	pool := &AccountPool{
+		rpcClient: rpcClient,
+	}
+	originAccount, err := pool.NewTestnetOriginAccount(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create and fund origin account: %v", err)
+	}
+	pool.originAccount = originAccount
+
+	// Fund worker accounts with 10k XLM each to ensure they have enough balance for the test
+	accounts, err := pool.FundWorkers(ctx, 10000, numAccounts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fund worker accounts: %v", err)
+	}
+	pool.accounts = accounts
+	return pool, nil
+}
+
+func (p *AccountPool) Close() {
+	// direct all funds from worker accounts back to origin account
+}
+
+// Creates and funds all workers in the pool with the specified amount from the origin account
+func (p *AccountPool) FundWorkers(ctx context.Context, amountPerWorker uint64, numWorkers uint32) ([]*WorkerAccount, error) {
+	if amountPerWorker*uint64(numWorkers) > p.originAccount.Balance.Load() {
+		return nil, fmt.Errorf("origin account does not have enough balance to fund workers")
+	}
+	sa := p.originAccount
+	accounts := make([]*WorkerAccount, numWorkers)
+	// For each worker account, send a payment from the origin account to fund it
+	for i := range accounts {
+		workerKp, err := keypair.Random()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate random keypair: %v", err)
+		}
+		accounts[i] = &WorkerAccount{Keypair: workerKp}
+
+		if err := sa.SendPaymentTo(ctx, p, accounts[i], amountPerWorker, p.passphrase); err != nil {
+			return nil, fmt.Errorf("failed to fund worker account %s: %v", workerKp.Address(), err)
+		}
+	}
+	// Wait for ledger close so all accounts visible on-chain, then fetch all sequence numbers
+	if ok, err := VerifyOnChainAndStore(ctx, p.rpcClient, accounts); err != nil || !ok {
+		return nil, fmt.Errorf("failed to verify accounts on-chain: %v", err)
+	}
+
+	return accounts, nil
+}
+
+// Creates a new origin account using friendbot
+func (p *AccountPool) NewTestnetOriginAccount(ctx context.Context) (*WorkerAccount, error) {
+	friendbotUrlReq, err := p.rpcClient.GetNetwork(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get friendbot URL: %v", err)
+	} else if friendbotUrlReq.FriendbotURL == "" {
+		return nil, fmt.Errorf("network does not have friendbot URL (check RPC config?)")
+	}
+
+	kp, err := keypair.Random()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate random keypair: %v", err)
+	}
+	acct := &WorkerAccount{Keypair: kp}
+	if err := acct.fundTestnetAccount(friendbotUrlReq.FriendbotURL); err != nil {
+		return nil, fmt.Errorf("failed to fund origin account %s: %v", kp.Address(), err)
+	}
+
+	if ok, err := VerifyOnChainAndStore(ctx, p.rpcClient, []*WorkerAccount{acct}); err != nil || !ok {
+		return nil, fmt.Errorf("failed to verify origin account on-chain: %v", err)
+	}
+
+	return acct, nil
+}
+
+// Get the next account and its current sequence number, and increment the sequence for the next call
+func (p *AccountPool) Next() (*WorkerAccount, int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	i := p.idx
+	acct := p.accounts[i%int64(len(p.accounts))]
+	p.idx++
+	return acct, acct.Id.Add(1) - 1
+}

--- a/internal/run/parameters/tx/worker_pool.go
+++ b/internal/run/parameters/tx/worker_pool.go
@@ -25,7 +25,7 @@ type AccountPool struct {
 }
 
 // Makes a pool of workers and funds each of them with testnet friendbot XLM
-func NewTestnetAccountPool(
+func NewAccountPool(
 	ctx context.Context,
 	rpcClient *rpcclient.Client,
 	originAccountKp *keypair.Full, // optional param to specify funding account
@@ -34,14 +34,24 @@ func NewTestnetAccountPool(
 	pool := &AccountPool{
 		rpcClient: rpcClient,
 	}
+	// Validate and set up network based on its type
 	getNetworkResponse, err := pool.rpcClient.GetNetwork(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get network info: %v", err)
 	}
-	pool.friendbotURL = getNetworkResponse.FriendbotURL
+	network, err := util.IsPubnetOrTestnet(getNetworkResponse.Passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine network type: %v", err)
+	}
+	if network == "testnet" {
+		pool.friendbotURL = getNetworkResponse.FriendbotURL
+	} else if originAccountKp == nil {
+		return nil, fmt.Errorf("origin account keypair must be provided for pubnet")
+	}
 	pool.passphrase = getNetworkResponse.Passphrase
 
-	originAccount, err := pool.NewTestnetOriginAccount(ctx, originAccountKp)
+	// Set up origin account struct
+	originAccount, err := pool.NewOriginAccount(ctx, originAccountKp, network)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create and fund origin account: %v", err)
 	}
@@ -144,11 +154,11 @@ func (p *AccountPool) FundWorkers(ctx context.Context, budgetPerWorker int64, nu
 }
 
 // Creates a new origin account using friendbot
-func (p *AccountPool) NewTestnetOriginAccount(ctx context.Context, originAccountKp *keypair.Full) (*WorkerAccount, error) {
+func (p *AccountPool) NewOriginAccount(ctx context.Context, originAccountKp *keypair.Full, network string) (*WorkerAccount, error) {
 	acct := &WorkerAccount{}
 	if originAccountKp != nil {
 		acct = &WorkerAccount{Keypair: originAccountKp}
-	} else {
+	} else if network == "testnet" {
 		kp, err := keypair.Random()
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate random keypair: %v", err)

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -48,5 +48,9 @@ const (
 	// Minimum balance (in XLM) for worker accounts to ensure they can send transactions throughout the test
 	MinimumWorkerBalance = 10
 	StroopsPerXLM        = 1 * 1e7
-	FeeTolerance         = 1000 // extra fee buffer in stroops to account for fee fluctuations during the test when verifying worker account balances at the end
+	FeeTolerance         = 1000 // stroop-fee buffer to account for fee fluctuations when verifying balances
+
+	WorkerMergeRetryWindow = time.Second * 90
+	WorkerMergeRetryPause  = 5 * time.Second
+	UnmergedWorkersPath    = "./output/unmerged_workers.json"
 )

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -43,8 +43,8 @@ const (
 
 // sendTransaction parameters for run
 const (
-	// Number of accounts to create and rotate through for sendTransaction requests in run
-	MaxSendTxAccounts = 100
+	// Max number of accounts to create per transaction when funding worker accounts
+	MaxCreateAccountsPerTx = 100
 	// Minimum balance (in XLM) for worker accounts to ensure they can send transactions throughout the test
 	MinimumWorkerBalance = 10
 	StroopsPerXLM        = 1 * 1e7

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -40,3 +40,13 @@ const (
 	PrEventTypeFilter     float64 = 0.5 // probability of including an event type filter
 	PrEventTopicFilter    float64 = 0.5 // probability of including a topic filter
 )
+
+// sendTransaction parameters for run
+const (
+	// Number of accounts to create and rotate through for sendTransaction requests in run
+	MaxSendTxAccounts = 100
+	// Minimum balance (in XLM) for worker accounts to ensure they can send transactions throughout the test
+	MinimumWorkerBalance = 10
+	StroopsPerXLM        = 1 * 1e7
+	FeeTolerance         = 1000 // extra fee buffer in stroops to account for fee fluctuations during the test when verifying worker account balances at the end
+)

--- a/internal/util/network.go
+++ b/internal/util/network.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -17,5 +18,16 @@ func SharedHTTPClient() *http.Client {
 			MaxIdleConns:        0,                  // unlimited, MaxIdleConnsPerHost limits per-host idle connections
 			IdleConnTimeout:     RequestTimeout * 3, // keep connections warm for a few request cycles
 		},
+	}
+}
+
+func IsPubnetOrTestnet(networkPassphrase string) (string, error) {
+	switch networkPassphrase {
+	case "Public Global Stellar Network ; September 2015":
+		return "pubnet", nil
+	case "Test SDF Network ; September 2015":
+		return "testnet", nil
+	default:
+		return "", fmt.Errorf("unknown network passphrase: %s", networkPassphrase)
 	}
 }

--- a/internal/util/request_builder.go
+++ b/internal/util/request_builder.go
@@ -1,8 +1,20 @@
 package util
 
 import (
+	"encoding/json"
+
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
+
+func MarshalJsonRpcRequest(method string, params map[string]any) ([]byte, error) {
+	req := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  method,
+		"params":  params,
+	}
+	return json.Marshal(req)
+}
 
 func MakeGetTransactionsRequest(start uint32, cursor string) protocol.GetTransactionsRequest {
 	req := protocol.GetTransactionsRequest{

--- a/internal/util/request_builder.go
+++ b/internal/util/request_builder.go
@@ -52,3 +52,9 @@ func MakeGetEventsRequest(start uint32, end uint32, cursor *protocol.Cursor) pro
 	}
 	return req
 }
+
+func MakeSendTransactionRequest(txB64 string) protocol.SendTransactionRequest {
+	return protocol.SendTransactionRequest{
+		Transaction: txB64,
+	}
+}


### PR DESCRIPTION
Note: This PR is currently not to be reviewed, as significant changes to the base branch are underway.

### What
Adds support for `simulateTransaction` and `sendTransaction` as load-testable RPC endpoints:
- `simulateTransaction` builds a static PaymentToContract transaction with zero account IDs and zero destination contract IDs. Sent at rate `RPS` in a manner similar to non-data-dependent endpoints.
- sendTransaction builds a pool of worker accounts funded by a provided source account. These worker accounts send signed self-payment transactions in parallel and are scheduled round-robin. 
    - For `sendTransaction`, if one is testing on `testnet,` they have the option of not supplying a pre-funded user account. However, they may if they wish, and if they wish to test on `pubnet`, then they must. This can be specified in the `toml` file as a secret seed from which their keypair may be parsed.

### Why 
These are the final endpoints that must be supported by stellar-rpc-blaster, and differ from the others because they're not read-only. They require actual signed transaction envelopes rather than canned JSON parameters. This branch builds transaction construction, account lifecycle (source account -> workers seeded with funds -> workers coalesced into source account), and infrastructure needed to generate realistic load against these endpoints.

### Known limitations
N/A