### PR TITLE
Add getEvents support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Example usage on localhost RPC testnet instance (note that instance must be runn
 
 To generate data for the `generate` command, example usage is as follows:
 ```
-./stellar-rpc-loadtest generate \
+./stellar-rpc-blaster generate \
   --rpc-url <RPC_URL> \
   [--output <PATH_TO_REQUEST_DATA_DAT>] \
   [--ledger-window START[,END]]

--- a/internal/app.go
+++ b/internal/app.go
@@ -96,7 +96,7 @@ func (a *App) init(ctx context.Context, runtimeSettings config.RuntimeSettings) 
 
 	a.client = util.SharedHTTPClient()
 	if a.config, err = config.NewConfig(ctx, runtimeSettings, a.logger, a.client); err != nil {
-		return fmt.Errorf("Could not load configuration: %v", err)
+		return fmt.Errorf("Could not load configuration: %w", err)
 	}
 	return nil
 }
@@ -128,7 +128,7 @@ func (a *App) runLoadTest(ctx context.Context) error {
 func (a *App) runGenerate(ctx context.Context) error {
 	g, err := generate.NewGenerator(ctx, a.config)
 	if err != nil {
-		return fmt.Errorf("could not make new generator: %v", err)
+		return fmt.Errorf("could not make new generator: %w", err)
 	}
 	return g.Generate(ctx, a.logger, a.config)
 }

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -24,6 +24,9 @@ rps = 20
 rps = 20
 
 # Parameter-based/generate-required endpoints
+[endpoints.getEvents]
+rps = 20
+
 [endpoints.getLedgerEntries]
 rps = 20
 

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -99,7 +99,7 @@ func NewConfig(
 	cfg.ConfigPath = settings.ConfigPath
 	cfg.RpcUrl = settings.RpcUrl
 	cfg.Mode = settings.Mode
-	logger.Debugf("Requested %v mode", settings.Mode.Name())
+	logger.Debugf("Requested %s mode", settings.Mode.Name())
 	switch cfg.Mode {
 	case Run:
 		cfg.Duration = settings.Duration
@@ -113,7 +113,7 @@ func NewConfig(
 		cfg.LedgerWindow = settings.LedgerWindow
 		cfg.Count = settings.Count
 	default:
-		return Config{}, fmt.Errorf("unknown mode: %v", cfg.Mode)
+		return Config{}, fmt.Errorf("unknown mode: %s", cfg.Mode.Name())
 	}
 
 	logger.Infof("Successfully loaded config from %s", settings.ConfigPath)

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -171,3 +171,14 @@ func (c *Config) GetEndpointRPS(key string) int {
 	}
 	return 0
 }
+
+// GetActiveEndpoints returns the endpoints configured with RPS > 0.
+func (c *Config) GetActiveEndpoints() []string {
+	activeEndpoints := make([]string, 0, len(c.Endpoints))
+	for _, endpointKey := range c.GetEndpoints() {
+		if c.GetEndpointRPS(endpointKey) > 0 {
+			activeEndpoints = append(activeEndpoints, endpointKey)
+		}
+	}
+	return activeEndpoints
+}

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -91,7 +91,7 @@ func NewConfig(
 	cfg.RpcClient = rpcclient.NewClient(settings.RpcUrl, client)
 
 	if getNetworkResponse, err := cfg.RpcClient.GetNetwork(ctx); err != nil {
-		return Config{}, fmt.Errorf("failed to fetch network passphrase: %v", err)
+		return Config{}, fmt.Errorf("failed to fetch network passphrase: %w", err)
 	} else {
 		cfg.NetworkPassphrase = getNetworkResponse.Passphrase
 	}
@@ -125,12 +125,12 @@ func (c *Config) processToml(tomlPath string) error {
 	// Load config TOML file
 	cfg, err := toml.LoadFile(tomlPath)
 	if err != nil {
-		return fmt.Errorf("config file \"%s\" was not found: %v", tomlPath, err)
+		return fmt.Errorf("config file \"%s\" was not found: %w", tomlPath, err)
 	}
 
 	// Unmarshal TOML data into the Config struct
 	if err = cfg.Unmarshal(c); err != nil {
-		return fmt.Errorf("error unmarshalling TOML config: %v", err)
+		return fmt.Errorf("error unmarshalling TOML config: %w", err)
 	}
 
 	if c.Mode == Run {
@@ -150,7 +150,7 @@ func (c *Config) validateEndpointConfig() error {
 			hasValidEndpoint = true
 		}
 		if needs, err := parameters.EndpointNeedsData(endpoint); err != nil {
-			return fmt.Errorf("failed to check if endpoint %s needs data: %v", endpoint, err)
+			return fmt.Errorf("failed to check if endpoint %s needs data: %w", endpoint, err)
 		} else if needs && c.InputDataPath == "" {
 			return fmt.Errorf("endpoint %s requires input data, but no input-data-path was provided", endpoint)
 		}

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stellar/stellar-rpc-blaster/internal/config"
 	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
-	"github.com/stellar/stellar-rpc-blaster/internal/generate/writer"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
 
@@ -56,7 +55,7 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	}
 	start := time.Now()
 
-	writer, err := writer.NewSeedWriter(cfg.OutputPath)
+	writer, err := seed.NewSeedWriter(cfg.OutputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create seed writer: %v", err)
 	}
@@ -69,7 +68,7 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	if err := seed.RunSeeder(ctx, g.parameters, txHashSeeder); err != nil {
 		return fmt.Errorf("failed to seed transaction hash data: %v", err)
 	}
-	writer.TxHashes = txHashSeeder.Results()
+	txHashSeeder.WriteResults(writer)
 	logger.Infof("Successfully fetched %d transaction hashes %s",
 		len(writer.TxHashes), util.LogElapsed(start))
 
@@ -78,7 +77,7 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	if err := seed.RunSeeder(ctx, g.parameters, eventSeeder); err != nil {
 		return fmt.Errorf("failed to seed events data: %v", err)
 	}
-	writer.ContractEventData = eventSeeder.Results()
+	eventSeeder.WriteResults(writer)
 	logger.Infof("Successfully fetched %d contracts and their associated event topics %s",
 		len(writer.ContractEventData.ContractIds), util.LogElapsed(start))
 
@@ -87,7 +86,7 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	if err := seed.RunSeeder(ctx, g.parameters, ledgerKeySeeder); err != nil {
 		return fmt.Errorf("failed to seed ledger keys: %v", err)
 	}
-	writer.LedgerKeys = ledgerKeySeeder.Results()
+	ledgerKeySeeder.WriteResults(writer)
 	logger.Infof("Successfully fetched %d ledger keys %s", len(writer.LedgerKeys), util.LogElapsed(start))
 
 	if err := writer.Close(); err != nil {

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc-blaster/internal/config"
@@ -14,35 +13,44 @@ import (
 )
 
 type Generator struct {
-	rpcUrl     string
-	client     *rpcclient.Client
+	Seeders    []seed.Seeder
+	Writer     *seed.SeedWriter
 	parameters seed.PreseedParameters
 }
 
-func NewGenerator(ctx context.Context, config config.Config) (*Generator, error) {
-	window, err := seed.GetLedgerRange(ctx, config.RpcClient, config.LedgerWindow, config.Count)
+func NewGenerator(ctx context.Context, cfg config.Config) (*Generator, error) {
+	window, err := seed.GetLedgerRange(ctx, cfg.RpcClient, cfg.LedgerWindow, cfg.Count)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ledger range for generation: %v", err)
 	}
 
 	parameters := seed.PreseedParameters{
-		ExportPath: config.OutputPath,
+		ExportPath: cfg.OutputPath,
 		Range:      window,
 	}
 
 	// If the window contains more ledgers than count, sample uniformly
-	if config.Count < window.Last-window.First+1 {
-		sampledLedgers, err := seed.ComputeSampledLedgers(window, config.Count)
+	if cfg.Count < window.Last-window.First+1 {
+		sampledLedgers, err := seed.ComputeSampledLedgers(window, cfg.Count)
 		if err != nil {
 			return nil, fmt.Errorf("could not get sample of ledgers: %v", err)
 		}
 		parameters.ProcessingRanges = seed.GroupSampledLedgersIntoRanges(sampledLedgers)
 	}
 
+	writer, err := seed.NewSeedWriter(cfg.OutputPath, parameters.Range)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create seed writer: %v", err)
+	}
+
 	return &Generator{
-		rpcUrl:     config.RpcUrl,
-		client:     config.RpcClient,
 		parameters: parameters,
+		Writer:     writer,
+		Seeders: []seed.Seeder{
+			seed.NewTxHashSeeder(cfg.RpcClient),
+			seed.NewEventDataSeeder(cfg.RpcClient),
+			seed.NewLedgerKeySeeder(cfg.RpcClient),
+		},
 	}, nil
 }
 
@@ -55,27 +63,15 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	}
 	start := time.Now()
 
-	writer, err := seed.NewSeedWriter(cfg.OutputPath)
-	if err != nil {
-		return fmt.Errorf("failed to create seed writer: %v", err)
-	}
-
-	// Set the ledger range
-	writer.LedgerRange = g.parameters.Range
-
-	for _, s := range []seed.Seeder{
-		seed.NewTxHashSeeder(g.client, logger),
-		seed.NewEventDataSeeder(g.client, logger),
-		seed.NewLedgerKeySeeder(g.client, logger),
-	} {
+	for _, s := range g.Seeders {
 		if err := seed.RunSeeder(ctx, g.parameters, s); err != nil {
 			return fmt.Errorf("failed to run seeder for %s: %v", s, err)
 		}
-		s.WriteResults(writer)
+		s.WriteResults(g.Writer)
 		logger.Infof("Successfully fetched %s %s", s, util.LogElapsed(start))
 	}
 
-	if err := writer.Close(); err != nil {
+	if err := g.Writer.Close(); err != nil {
 		return fmt.Errorf("failed to close seed writer: %v", err)
 	}
 

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -73,6 +73,15 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	logger.Infof("Successfully fetched %d transaction hashes %s",
 		len(writer.TxHashes), util.LogElapsed(start))
 
+	// Bootstrap per-contract event topic associations within the ledger range
+	eventSeeder := seed.NewEventDataSeeder(g.client, logger)
+	if err := seed.RunSeeder(ctx, g.parameters, eventSeeder); err != nil {
+		return fmt.Errorf("failed to seed events data: %v", err)
+	}
+	writer.ContractEventData = eventSeeder.Results()
+	logger.Infof("Successfully fetched %d contracts and their associated event topics %s",
+		len(writer.ContractEventData.ContractIds), util.LogElapsed(start))
+
 	// Seed ledger keys
 	ledgerKeySeeder := seed.NewLedgerKeySeeder(g.client, logger)
 	if err := seed.RunSeeder(ctx, g.parameters, ledgerKeySeeder); err != nil {

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -63,31 +63,17 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 	// Set the ledger range
 	writer.LedgerRange = g.parameters.Range
 
-	// Bootstrap transaction hashes and success status within the ledger range
-	txHashSeeder := seed.NewTxHashSeeder(g.client, logger)
-	if err := seed.RunSeeder(ctx, g.parameters, txHashSeeder); err != nil {
-		return fmt.Errorf("failed to seed transaction hash data: %v", err)
+	for _, s := range []seed.Seeder{
+		seed.NewTxHashSeeder(g.client, logger),
+		seed.NewEventDataSeeder(g.client, logger),
+		seed.NewLedgerKeySeeder(g.client, logger),
+	} {
+		if err := seed.RunSeeder(ctx, g.parameters, s); err != nil {
+			return fmt.Errorf("failed to run seeder for %s: %v", s, err)
+		}
+		s.WriteResults(writer)
+		logger.Infof("Successfully fetched %s %s", s, util.LogElapsed(start))
 	}
-	txHashSeeder.WriteResults(writer)
-	logger.Infof("Successfully fetched %d transaction hashes %s",
-		len(writer.TxHashes), util.LogElapsed(start))
-
-	// Bootstrap per-contract event topic associations within the ledger range
-	eventSeeder := seed.NewEventDataSeeder(g.client, logger)
-	if err := seed.RunSeeder(ctx, g.parameters, eventSeeder); err != nil {
-		return fmt.Errorf("failed to seed events data: %v", err)
-	}
-	eventSeeder.WriteResults(writer)
-	logger.Infof("Successfully fetched %d contracts and their associated event topics %s",
-		len(writer.ContractEventData.ContractIds), util.LogElapsed(start))
-
-	// Seed ledger keys
-	ledgerKeySeeder := seed.NewLedgerKeySeeder(g.client, logger)
-	if err := seed.RunSeeder(ctx, g.parameters, ledgerKeySeeder); err != nil {
-		return fmt.Errorf("failed to seed ledger keys: %v", err)
-	}
-	ledgerKeySeeder.WriteResults(writer)
-	logger.Infof("Successfully fetched %d ledger keys %s", len(writer.LedgerKeys), util.LogElapsed(start))
 
 	if err := writer.Close(); err != nil {
 		return fmt.Errorf("failed to close seed writer: %v", err)

--- a/internal/generate/generator.go
+++ b/internal/generate/generator.go
@@ -21,7 +21,7 @@ type Generator struct {
 func NewGenerator(ctx context.Context, cfg config.Config) (*Generator, error) {
 	window, err := seed.GetLedgerRange(ctx, cfg.RpcClient, cfg.LedgerWindow, cfg.Count)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ledger range for generation: %v", err)
+		return nil, fmt.Errorf("failed to get ledger range for generation: %w", err)
 	}
 
 	parameters := seed.PreseedParameters{
@@ -33,14 +33,14 @@ func NewGenerator(ctx context.Context, cfg config.Config) (*Generator, error) {
 	if cfg.Count < window.Last-window.First+1 {
 		sampledLedgers, err := seed.ComputeSampledLedgers(window, cfg.Count)
 		if err != nil {
-			return nil, fmt.Errorf("could not get sample of ledgers: %v", err)
+			return nil, fmt.Errorf("could not get sample of ledgers: %w", err)
 		}
 		parameters.ProcessingRanges = seed.GroupSampledLedgersIntoRanges(sampledLedgers)
 	}
 
 	writer, err := seed.NewSeedWriter(cfg.OutputPath, parameters.Range)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create seed writer: %v", err)
+		return nil, fmt.Errorf("failed to create seed writer: %w", err)
 	}
 
 	return &Generator{
@@ -65,14 +65,14 @@ func (g *Generator) Generate(ctx context.Context, logger *log.Entry, cfg config.
 
 	for _, s := range g.Seeders {
 		if err := seed.RunSeeder(ctx, g.parameters, s); err != nil {
-			return fmt.Errorf("failed to run seeder for %s: %v", s, err)
+			return fmt.Errorf("failed to run seeder for %s: %w", s, err)
 		}
 		s.WriteResults(g.Writer)
 		logger.Infof("Successfully fetched %s %s", s, util.LogElapsed(start))
 	}
 
 	if err := g.Writer.Close(); err != nil {
-		return fmt.Errorf("failed to close seed writer: %v", err)
+		return fmt.Errorf("failed to close seed writer: %w", err)
 	}
 
 	logger.Infof("Generated data written to %s %s", cfg.OutputPath, util.LogElapsed(start))

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -19,7 +19,7 @@ type EventDataSeeder struct {
 	contractEvents ContractEvents
 }
 
-func NewEventDataSeeder(rpcClient *rpcclient.Client, logger *log.Entry) *EventDataSeeder {
+func NewEventDataSeeder(rpcClient *rpcclient.Client, logger *log.Entry) Seeder {
 	return &EventDataSeeder{
 		rpcClient:    rpcClient,
 		logger:       logger,
@@ -30,9 +30,9 @@ func NewEventDataSeeder(rpcClient *rpcclient.Client, logger *log.Entry) *EventDa
 	}
 }
 
-// Results returns the accumulated event data as a serializable EventData.
-func (s *EventDataSeeder) Results() ContractEvents {
-	return s.contractEvents
+// WriteResults writes the accumulated event data to the SeedWriter.
+func (s *EventDataSeeder) WriteResults(w *SeedWriter) {
+	w.ContractEventData = s.contractEvents
 }
 
 // SeedDataForRange implements Seeder for EventDataSeeder.

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
-	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
 )
@@ -14,15 +13,13 @@ import (
 // EventDataSeeder collects per-contract event topic associations with a shared topic dictionary.
 type EventDataSeeder struct {
 	rpcClient      *rpcclient.Client
-	logger         *log.Entry
 	uniqueTopics   []string // ordered list of unique topics
 	contractEvents ContractEvents
 }
 
-func NewEventDataSeeder(rpcClient *rpcclient.Client, logger *log.Entry) Seeder {
+func NewEventDataSeeder(rpcClient *rpcclient.Client) Seeder {
 	return &EventDataSeeder{
 		rpcClient:    rpcClient,
-		logger:       logger,
 		uniqueTopics: make([]string, 0, util.DefaultSeedSliceSize),
 		contractEvents: ContractEvents{
 			ContractIds: make(map[string]*TopicData, util.DefaultSeedSliceSize),

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -1,0 +1,71 @@
+package seed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/support/log"
+
+	"github.com/stellar/stellar-rpc-blaster/internal/util"
+)
+
+// EventDataSeeder collects per-contract event topic associations with a shared topic dictionary.
+type EventDataSeeder struct {
+	rpcClient      *rpcclient.Client
+	logger         *log.Entry
+	uniqueTopics   []string // ordered list of unique topics
+	contractEvents ContractEvents
+}
+
+func NewEventDataSeeder(rpcClient *rpcclient.Client, logger *log.Entry) *EventDataSeeder {
+	return &EventDataSeeder{
+		rpcClient:    rpcClient,
+		logger:       logger,
+		uniqueTopics: make([]string, 0, util.DefaultSeedSliceSize),
+		contractEvents: ContractEvents{
+			ContractIds: make(map[string]*TopicData, util.DefaultSeedSliceSize),
+		},
+	}
+}
+
+// Results returns the accumulated event data as a serializable EventData.
+func (s *EventDataSeeder) Results() ContractEvents {
+	return s.contractEvents
+}
+
+// SeedDataForRange implements Seeder for EventDataSeeder.
+// It fetches events for the given ledger range and accumulates per-contract topic associations.
+func (s *EventDataSeeder) SeedDataForRange(ctx context.Context, r Range) error {
+	limit := min(util.TxPageLimit, r.Last-r.First+1)
+
+	for start := r.First; start <= r.Last; start += limit {
+		endLedger := min(start+limit-1, r.Last)
+		var cursor *protocol.Cursor
+
+		for {
+			req := util.MakeGetEventsRequest(start, endLedger, cursor)
+			eventsResponse, err := s.rpcClient.GetEvents(ctx, req)
+			if err != nil {
+				return fmt.Errorf("failed to fetch event data for ledgers %d->%d: %v",
+					start, endLedger, err)
+			}
+
+			for _, event := range eventsResponse.Events {
+				cid := event.ContractID
+				s.contractEvents.AddEventData(cid, event)
+			}
+
+			if eventsResponse.Cursor == "" || len(eventsResponse.Events) == 0 {
+				break
+			}
+			c, err := protocol.ParseCursor(eventsResponse.Cursor)
+			if err != nil {
+				return fmt.Errorf("failed to parse events cursor %q: %v", eventsResponse.Cursor, err)
+			}
+			cursor = &c
+		}
+	}
+	return nil
+}

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -50,8 +50,7 @@ func (s *EventDataSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 			}
 
 			for _, event := range eventsResponse.Events {
-				cid := event.ContractID
-				s.contractEvents.AddEventData(cid, event)
+				s.contractEvents.AddEventData(event)
 			}
 
 			if eventsResponse.Cursor == "" || len(eventsResponse.Events) == 0 {

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -45,7 +45,7 @@ func (s *EventDataSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 			req := util.MakeGetEventsRequest(start, endLedger, cursor)
 			eventsResponse, err := s.rpcClient.GetEvents(ctx, req)
 			if err != nil {
-				return fmt.Errorf("failed to fetch event data for ledgers %d->%d: %v",
+				return fmt.Errorf("failed to fetch event data for ledgers %d->%d: %w",
 					start, endLedger, err)
 			}
 
@@ -58,7 +58,7 @@ func (s *EventDataSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 			}
 			c, err := protocol.ParseCursor(eventsResponse.Cursor)
 			if err != nil {
-				return fmt.Errorf("failed to parse events cursor %q: %v", eventsResponse.Cursor, err)
+				return fmt.Errorf("failed to parse events cursor %q: %w", eventsResponse.Cursor, err)
 			}
 			cursor = &c
 		}

--- a/internal/generate/seed/events_data.go
+++ b/internal/generate/seed/events_data.go
@@ -69,3 +69,7 @@ func (s *EventDataSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 	}
 	return nil
 }
+
+func (s *EventDataSeeder) String() string {
+	return "event data"
+}

--- a/internal/generate/seed/ledger_keys.go
+++ b/internal/generate/seed/ledger_keys.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
-	"github.com/stellar/go-stellar-sdk/support/log"
 	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
@@ -14,14 +13,12 @@ import (
 // LedgerKeySeeder collects XDR-encoded ledger keys from transaction metadata.
 type LedgerKeySeeder struct {
 	rpcClient *rpcclient.Client
-	logger    *log.Entry
 	entry     []string
 }
 
-func NewLedgerKeySeeder(rpcClient *rpcclient.Client, logger *log.Entry) Seeder {
+func NewLedgerKeySeeder(rpcClient *rpcclient.Client) Seeder {
 	return &LedgerKeySeeder{
 		rpcClient: rpcClient,
-		logger:    logger,
 		entry:     make([]string, 0, util.DefaultSeedSliceSize),
 	}
 }
@@ -61,9 +58,8 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 			keys, err := s.getKeysFromTxResultMeta(txResultMeta)
 			if err != nil {
-				s.logger.Errorf("failed to extract ledger keys from transaction result meta XDR for tx %s: %v",
+				return fmt.Errorf("failed to extract ledger keys from transaction result meta XDR for tx %s: %v",
 					tx.TransactionDetails.TransactionHash, err)
-				continue
 			}
 			for _, key := range keys {
 				switch key.Type {
@@ -78,9 +74,8 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 				keyXDR, err := xdr.MarshalBase64(key)
 				if err != nil {
-					s.logger.Errorf("failed to marshal ledger key to XDR for tx %s: %v",
+					return fmt.Errorf("failed to marshal ledger key to XDR for tx %s: %v",
 						tx.TransactionDetails.TransactionHash, err)
-					continue
 				}
 				s.entry = append(s.entry, keyXDR)
 			}
@@ -104,8 +99,7 @@ func (s *LedgerKeySeeder) getKeysFromTxResultMeta(resultMetaXDR string) ([]xdr.L
 	for _, change := range changes {
 		key, err := change.LedgerKey()
 		if err != nil {
-			s.logger.Errorf("failed to get ledger key from change: %v", err)
-			continue
+			return nil, fmt.Errorf("failed to get ledger key from change: %v", err)
 		}
 		out = append(out, key)
 	}

--- a/internal/generate/seed/ledger_keys.go
+++ b/internal/generate/seed/ledger_keys.go
@@ -147,3 +147,7 @@ func getLedgerEntryChangesFromMeta(meta xdr.TransactionMeta) ([]xdr.LedgerEntryC
 	}
 	return changes, true
 }
+
+func (s *LedgerKeySeeder) String() string {
+	return "ledger key data"
+}

--- a/internal/generate/seed/ledger_keys.go
+++ b/internal/generate/seed/ledger_keys.go
@@ -38,7 +38,7 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 		txsResponse, err := s.rpcClient.GetTransactions(ctx, req)
 		if err != nil {
-			return fmt.Errorf("failed to fetch transaction data from ledger %d, cursor %s: %v",
+			return fmt.Errorf("failed to fetch transaction data from ledger %d, cursor %s: %w",
 				r.First, cursor, err)
 		}
 
@@ -58,7 +58,7 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 			keys, err := s.getKeysFromTxResultMeta(txResultMeta)
 			if err != nil {
-				return fmt.Errorf("failed to extract ledger keys from transaction result meta XDR for tx %s: %v",
+				return fmt.Errorf("failed to extract ledger keys from transaction result meta XDR for tx %s: %w",
 					tx.TransactionDetails.TransactionHash, err)
 			}
 			for _, key := range keys {
@@ -74,7 +74,7 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 				keyXDR, err := xdr.MarshalBase64(key)
 				if err != nil {
-					return fmt.Errorf("failed to marshal ledger key to XDR for tx %s: %v",
+					return fmt.Errorf("failed to marshal ledger key to XDR for tx %s: %w",
 						tx.TransactionDetails.TransactionHash, err)
 				}
 				s.entry = append(s.entry, keyXDR)
@@ -87,7 +87,7 @@ func (s *LedgerKeySeeder) SeedDataForRange(ctx context.Context, r Range) error {
 func (s *LedgerKeySeeder) getKeysFromTxResultMeta(resultMetaXDR string) ([]xdr.LedgerKey, error) {
 	var meta xdr.TransactionMeta
 	if err := xdr.SafeUnmarshalBase64(resultMetaXDR, &meta); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal transaction result meta XDR: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal transaction result meta XDR: %w", err)
 	}
 
 	changes, ok := getLedgerEntryChangesFromMeta(meta)
@@ -99,7 +99,7 @@ func (s *LedgerKeySeeder) getKeysFromTxResultMeta(resultMetaXDR string) ([]xdr.L
 	for _, change := range changes {
 		key, err := change.LedgerKey()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get ledger key from change: %v", err)
+			return nil, fmt.Errorf("failed to get ledger key from change: %w", err)
 		}
 		out = append(out, key)
 	}

--- a/internal/generate/seed/ledger_keys.go
+++ b/internal/generate/seed/ledger_keys.go
@@ -18,7 +18,7 @@ type LedgerKeySeeder struct {
 	entry     []string
 }
 
-func NewLedgerKeySeeder(rpcClient *rpcclient.Client, logger *log.Entry) *LedgerKeySeeder {
+func NewLedgerKeySeeder(rpcClient *rpcclient.Client, logger *log.Entry) Seeder {
 	return &LedgerKeySeeder{
 		rpcClient: rpcClient,
 		logger:    logger,
@@ -26,9 +26,9 @@ func NewLedgerKeySeeder(rpcClient *rpcclient.Client, logger *log.Entry) *LedgerK
 	}
 }
 
-// Results returns the accumulated ledger keys.
-func (s *LedgerKeySeeder) Results() []string {
-	return s.entry
+// WriteResults writes the accumulated ledger keys to the SeedWriter.
+func (s *LedgerKeySeeder) WriteResults(w *SeedWriter) {
+	w.LedgerKeys = s.entry
 }
 
 // SeedDataForRange implements Seeder for LedgerKeySeeder.

--- a/internal/generate/seed/preseed.go
+++ b/internal/generate/seed/preseed.go
@@ -26,7 +26,7 @@ func GetLatestCheckpointLedger(ctx context.Context, rpcClient *rpcclient.Client)
 	checkpointManager := checkpoint.NewCheckpointManager(util.CheckpointFrequency)
 	latestLedger, err := rpcClient.GetLatestLedger(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("failed to fetch latest ledger: %v", err)
+		return 0, fmt.Errorf("failed to fetch latest ledger: %w", err)
 	}
 
 	return checkpointManager.PrevCheckpoint(latestLedger.Sequence), nil
@@ -41,7 +41,7 @@ func GetLedgerRange(
 ) (Range, error) {
 	latestCheckpointLedger, err := GetLatestCheckpointLedger(ctx, rpcClient)
 	if err != nil {
-		return Range{}, fmt.Errorf("failed to get latest checkpoint ledger: %v", err)
+		return Range{}, fmt.Errorf("failed to get latest checkpoint ledger: %w", err)
 	}
 
 	var first, last uint32

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -61,11 +61,11 @@ func (c *ContractEvents) AddEventData(contractId string, eventData protocol.Even
 	}
 }
 
-func (c *ContractEvents) BuildEventsFilter() map[string]any {
+func (c *ContractEvents) BuildEventsFilters() map[string]any {
 	var cIds []string
 	filter := make(map[string]any)
 	// Choose up to 5 random contract IDs
-	nCIds := rand.IntN(5)
+	nCIds := rand.IntN(6)
 	cIds = util.ChooseNAtRandom(c.getContractIds(), max(nCIds, 1))
 	if nCIds != 0 {
 		// In the 0 case, even though we picked one contract ID for filtering purposes, add none
@@ -77,7 +77,7 @@ func (c *ContractEvents) BuildEventsFilter() map[string]any {
 
 	refContractTopics := c.ContractIds[cIds[0]]
 	// Choose up to 5 random topics from the first contract ID's topics
-	nTopics := rand.IntN(5)
+	nTopics := rand.IntN(6)
 	alltopics, weights := refContractTopics.getTopicsAndWeights()
 	topics := util.WeightedChooseN(alltopics, weights, max(nTopics, 1))
 
@@ -90,7 +90,7 @@ func (c *ContractEvents) BuildEventsFilter() map[string]any {
 		params := allParams[rand.IntN(len(allParams))]
 
 		// choose up to 4 of the chosen invocation's parameters to include in the filter
-		nParams := min(rand.IntN(4), len(params))
+		nParams := min(rand.IntN(5), len(params))
 		entry = append(entry, params[:nParams]...)
 		topicsFilter = append(topicsFilter, entry)
 	}

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -1,8 +1,67 @@
 package seed
 
+import (
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/support/collections/set"
+	"github.com/stellar/stellar-rpc-blaster/internal/util"
+)
+
 // SeedData is the unified struct for writing and reading seed data across run and generate
 type SeedData struct {
-	LedgerRange Range    `json:"ledger_range"`
-	TxHashes    []string `json:"tx_hashes"`
-	LedgerKeys  []string `json:"ledger_keys"`
+	LedgerRange       Range          `json:"ledger_range"`
+	TxHashes          []string       `json:"tx_hashes"`
+	ContractEventData ContractEvents `json:"contract_events"`
+	LedgerKeys        []string       `json:"ledger_keys"`
+}
+
+// ContractEvents maps the contract IDs to their corresponding event data.
+type ContractEvents struct {
+	ContractIds map[string]*TopicData `json:"contract_ids"`
+}
+
+// TopicData maps a topic to the parameters observed for that topic.
+type TopicData struct {
+	Topic        map[string]ParamTopics `json:"topic"`
+	uniqueTopics set.Set[string]        // set of unique topics observed for this contract, used to determine if a topic is new or existing for this contract
+}
+
+// Holds the parameters we observe for a given topic.
+type ParamTopics struct {
+	Params [][]string `json:"params"`
+}
+
+/*
+for _, event := range eventsResponse.Events {
+	cid := event.ContractID
+	for _, topic := range event.TopicXDR {
+		s.contractEvents.AddEventData(cid, topic, event.Params)
+	}
+}
+*/
+
+func (c *ContractEvents) AddEventData(contractId string, eventData protocol.EventInfo) {
+	td, ok := c.ContractIds[contractId]
+	if !ok {
+		// new contract, add contract + topic + params
+		data := TopicData{
+			Topic:        map[string]ParamTopics{},
+			uniqueTopics: set.NewSet[string](int(util.DefaultSeedSliceSize)),
+		}
+		c.ContractIds[contractId] = &data
+		td = &data
+	}
+
+	topicXdr := eventData.TopicXDR
+	name := topicXdr[0]    // first topic is the event name
+	params := topicXdr[1:] // subsequent topics are the event parameters
+
+	if td.uniqueTopics.Contains(name) {
+		// contract + topic both exist
+		topicParams := td.Topic[name].Params
+		td.Topic[name] = ParamTopics{Params: append(topicParams, params)}
+	} else {
+		// contract exists, topic is new
+		td.uniqueTopics.Add(name)
+		td.Topic[name] = ParamTopics{Params: [][]string{params}}
+	}
 }

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -1,6 +1,10 @@
 package seed
 
 import (
+	"maps"
+	"math/rand/v2"
+	"slices"
+
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/go-stellar-sdk/support/collections/set"
 	"github.com/stellar/stellar-rpc-blaster/internal/util"
@@ -30,15 +34,6 @@ type ParamTopics struct {
 	Params [][]string `json:"params"`
 }
 
-/*
-for _, event := range eventsResponse.Events {
-	cid := event.ContractID
-	for _, topic := range event.TopicXDR {
-		s.contractEvents.AddEventData(cid, topic, event.Params)
-	}
-}
-*/
-
 func (c *ContractEvents) AddEventData(contractId string, eventData protocol.EventInfo) {
 	td, ok := c.ContractIds[contractId]
 	if !ok {
@@ -64,4 +59,58 @@ func (c *ContractEvents) AddEventData(contractId string, eventData protocol.Even
 		td.uniqueTopics.Add(name)
 		td.Topic[name] = ParamTopics{Params: [][]string{params}}
 	}
+}
+
+func (c *ContractEvents) BuildEventsFilter() map[string]any {
+	var cIds []string
+	filter := make(map[string]any)
+	// Choose up to 5 random contract IDs
+	nCIds := rand.IntN(5)
+	cIds = util.ChooseNAtRandom(c.getContractIds(), max(nCIds, 1))
+	if nCIds != 0 {
+		// In the 0 case, even though we picked one contract ID for filtering purposes, add none
+		filter["contractIds"] = cIds
+	}
+	if len(cIds) == 0 {
+		return filter
+	}
+
+	refContractTopics := c.ContractIds[cIds[0]]
+	// Choose up to 5 random topics from the first contract ID's topics
+	nTopics := rand.IntN(5)
+	alltopics, weights := refContractTopics.getTopicsAndWeights()
+	topics := util.WeightedChooseN(alltopics, weights, max(nTopics, 1))
+
+	// For each topic we chose, choose up to 4 parameters to include in that topic's filter
+	topicsFilter := make([][]string, 0, len(topics))
+	for _, topic := range topics {
+		entry := []string{topic} // first entry in the topic filter is the topic name
+		// choose some random parameters/invocation for this topic
+		allParams := refContractTopics.Topic[topic].Params
+		params := allParams[rand.IntN(len(allParams))]
+
+		// choose up to 4 of the chosen invocation's parameters to include in the filter
+		nParams := min(rand.IntN(4), len(params))
+		entry = append(entry, params[:nParams]...)
+		topicsFilter = append(topicsFilter, entry)
+	}
+
+	if nTopics != 0 {
+		filter["topics"] = topicsFilter
+	}
+	return filter
+}
+
+func (c ContractEvents) getContractIds() []string {
+	return slices.Collect(maps.Keys(c.ContractIds))
+}
+
+func (t TopicData) getTopicsAndWeights() ([]string, []int) {
+	topics := make([]string, 0, len(t.Topic))
+	weights := make([]int, 0, len(t.Topic))
+	for topic, pt := range t.Topic {
+		topics = append(topics, topic)
+		weights = append(weights, len(pt.Params))
+	}
+	return topics, weights
 }

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -61,6 +61,7 @@ func (c *ContractEvents) AddEventData(contractId string, eventData protocol.Even
 	}
 }
 
+// BuildEventsFilters builds a filter map for a getEvents request based on our contract event seed data.
 func (c *ContractEvents) BuildEventsFilters() map[string]any {
 	var cIds []string
 	filter := make(map[string]any)
@@ -76,7 +77,7 @@ func (c *ContractEvents) BuildEventsFilters() map[string]any {
 	}
 
 	refContractTopics := c.ContractIds[cIds[0]]
-	// Choose up to 5 random topics from the first contract ID's topics
+	// Choose up to 5 random topics (weighted by their probability of occurrence) from the first contract ID's topics
 	nTopics := rand.IntN(6)
 	alltopics, weights := refContractTopics.getTopicsAndWeights()
 	topics := util.WeightedChooseN(alltopics, weights, max(nTopics, 1))
@@ -85,9 +86,9 @@ func (c *ContractEvents) BuildEventsFilters() map[string]any {
 	topicsFilter := make([][]string, 0, len(topics))
 	for _, topic := range topics {
 		entry := []string{topic} // first entry in the topic filter is the topic name
-		// choose some random parameters/invocation for this topic
-		allParams := refContractTopics.Topic[topic].Params
-		params := allParams[rand.IntN(len(allParams))]
+		// select one parameter set for topic out of the sets of parameters we observed for this topic in seed data
+		allParamsForTopic := refContractTopics.Topic[topic].Params
+		params := allParamsForTopic[rand.IntN(len(allParamsForTopic))]
 
 		// choose up to 4 of the chosen invocation's parameters to include in the filter
 		nParams := min(rand.IntN(5), len(params))

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -34,15 +34,16 @@ type ParamTopics struct {
 	Params [][]string `json:"params"`
 }
 
-func (c *ContractEvents) AddEventData(contractId string, eventData protocol.EventInfo) {
-	td, ok := c.ContractIds[contractId]
+func (c *ContractEvents) AddEventData(eventData protocol.EventInfo) {
+	cId := eventData.ContractID
+	td, ok := c.ContractIds[cId]
 	if !ok {
 		// new contract, add contract + topic + params
 		data := TopicData{
 			Topic:        map[string]ParamTopics{},
 			uniqueTopics: set.NewSet[string](int(util.DefaultSeedSliceSize)),
 		}
-		c.ContractIds[contractId] = &data
+		c.ContractIds[cId] = &data
 		td = &data
 	}
 

--- a/internal/generate/seed/seed_data.go
+++ b/internal/generate/seed/seed_data.go
@@ -85,7 +85,7 @@ func (c *ContractEvents) BuildEventsFilters() map[string]any {
 	// For each topic we chose, choose up to 4 parameters to include in that topic's filter
 	topicsFilter := make([][]string, 0, len(topics))
 	for _, topic := range topics {
-		entry := []string{topic} // first entry in the topic filter is the topic name
+		entry := []string{topic} // first entry in the topic filter is, generally, the topic name
 		// select one parameter set for topic out of the sets of parameters we observed for this topic in seed data
 		allParamsForTopic := refContractTopics.Topic[topic].Params
 		params := allParamsForTopic[rand.IntN(len(allParamsForTopic))]

--- a/internal/generate/seed/seeder.go
+++ b/internal/generate/seed/seeder.go
@@ -11,6 +11,7 @@ type Seeder interface {
 	SeedDataForRange(ctx context.Context, r Range) error
 	// WriteResults writes the accumulated data to the given SeedWriter.
 	WriteResults(w *SeedWriter)
+	String() string
 }
 
 // RunSeeder iterates over processing ranges and delegates collection to the given Seeder for each range.

--- a/internal/generate/seed/seeder.go
+++ b/internal/generate/seed/seeder.go
@@ -5,13 +5,12 @@ import (
 )
 
 // Seeder processes seed data for a specific RPC data type across ledger ranges.
-// Each implementation holds its own accumulator state and exposes result getters on the struct.
+// Each implementation holds its own accumulator state and writes results to a SeedWriter.
 type Seeder interface {
 	// SeedDataForRange collects data from a single ledger range.
-	SeedDataForRange(
-		ctx context.Context,
-		r Range,
-	) error
+	SeedDataForRange(ctx context.Context, r Range) error
+	// WriteResults writes the accumulated data to the given SeedWriter.
+	WriteResults(w *SeedWriter)
 }
 
 // RunSeeder iterates over processing ranges and delegates collection to the given Seeder for each range.

--- a/internal/generate/seed/tx_hash.go
+++ b/internal/generate/seed/tx_hash.go
@@ -16,10 +16,9 @@ type TxHashSeeder struct {
 	data      []string
 }
 
-func NewTxHashSeeder(rpcClient *rpcclient.Client, logger *log.Entry) *TxHashSeeder {
+func NewTxHashSeeder(rpcClient *rpcclient.Client) *TxHashSeeder {
 	return &TxHashSeeder{
 		rpcClient: rpcClient,
-		logger:    logger,
 		data:      make([]string, 0, util.DefaultSeedSliceSize),
 	}
 }

--- a/internal/generate/seed/tx_hash.go
+++ b/internal/generate/seed/tx_hash.go
@@ -24,9 +24,9 @@ func NewTxHashSeeder(rpcClient *rpcclient.Client, logger *log.Entry) *TxHashSeed
 	}
 }
 
-// Results returns the accumulated transaction hash data.
-func (s *TxHashSeeder) Results() []string {
-	return s.data
+// WriteResults writes the accumulated transaction hashes to the SeedWriter.
+func (s *TxHashSeeder) WriteResults(w *SeedWriter) {
+	w.TxHashes = s.data
 }
 
 // SeedDataForRange implements Seeder for TxHashSeeder by getting hashes and categorizing them by success or failure.

--- a/internal/generate/seed/tx_hash.go
+++ b/internal/generate/seed/tx_hash.go
@@ -54,3 +54,7 @@ func (s *TxHashSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 	}
 	return nil
 }
+
+func (s *TxHashSeeder) String() string {
+	return "transaction hash data"
+}

--- a/internal/generate/seed/tx_hash.go
+++ b/internal/generate/seed/tx_hash.go
@@ -36,7 +36,7 @@ func (s *TxHashSeeder) SeedDataForRange(ctx context.Context, r Range) error {
 
 		txsResponse, err := s.rpcClient.GetTransactions(ctx, req)
 		if err != nil {
-			return fmt.Errorf("failed to fetch transaction data for ledger %d, cursor %s: %v", r.First, cursor, err)
+			return fmt.Errorf("failed to fetch transaction data for ledger %d, cursor %s: %w", r.First, cursor, err)
 		}
 		if len(txsResponse.Transactions) == 0 {
 			break

--- a/internal/generate/seed/writer.go
+++ b/internal/generate/seed/writer.go
@@ -1,4 +1,4 @@
-package writer
+package seed
 
 import (
 	"encoding/json"
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
 )
 
 var (
@@ -19,7 +17,7 @@ var (
 // then encodes it as a single ordered JSON object on Flush().
 type SeedWriter struct {
 	io.WriteCloser
-	seed.SeedData
+	SeedData
 }
 
 func NewSeedWriter(path string) (*SeedWriter, error) {

--- a/internal/generate/seed/writer.go
+++ b/internal/generate/seed/writer.go
@@ -23,7 +23,7 @@ type SeedWriter struct {
 func NewSeedWriter(path string, ledgerRange Range) (*SeedWriter, error) {
 	f, err := os.Create(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create seed file %s: %v", path, err)
+		return nil, fmt.Errorf("failed to create seed file %s: %w", path, err)
 	}
 	sw := SeedWriter{
 		WriteCloser: f,
@@ -43,10 +43,10 @@ func (w *SeedWriter) Write(bytes []byte) (int, error) {
 func (w *SeedWriter) Close() error {
 	data, err := w.MarshalJSON()
 	if err != nil {
-		return errors.Join(fmt.Errorf("failed to marshal seed data to JSON: %v", err), w.WriteCloser.Close())
+		return errors.Join(fmt.Errorf("failed to marshal seed data to JSON: %w", err), w.WriteCloser.Close())
 	}
 	if _, err := w.Write(data); err != nil {
-		return errors.Join(fmt.Errorf("failed to write seed data to file: %v", err), w.WriteCloser.Close())
+		return errors.Join(fmt.Errorf("failed to write seed data to file: %w", err), w.WriteCloser.Close())
 	}
 	return w.WriteCloser.Close()
 }

--- a/internal/generate/seed/writer.go
+++ b/internal/generate/seed/writer.go
@@ -20,14 +20,16 @@ type SeedWriter struct {
 	SeedData
 }
 
-func NewSeedWriter(path string) (*SeedWriter, error) {
+func NewSeedWriter(path string, ledgerRange Range) (*SeedWriter, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create seed file %s: %v", path, err)
 	}
-	return &SeedWriter{
+	sw := SeedWriter{
 		WriteCloser: f,
-	}, nil
+	}
+	sw.LedgerRange = ledgerRange
+	return &sw, nil
 }
 
 func (w *SeedWriter) MarshalJSON() ([]byte, error) {

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -60,7 +60,7 @@ func RunVegeta(
 	for _, endpointKey := range cfg.GetEndpoints() {
 		rps := cfg.GetEndpointRPS(endpointKey)
 		if rps <= 0 {
-			logger.Infof("Skipping endpoint: %v (RPS <= 0)", endpointKey)
+			logger.Infof("Skipping endpoint: %s (RPS <= 0)", endpointKey)
 			continue
 		}
 

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -48,6 +48,7 @@ func RunVegeta(
 		}
 		sharedParams = p
 
+		// Run preflight validation to ensure seed data is fresh enough for the target RPC before blasting any endpoints
 		validator := parameters.NewEndpointSeedValidator(cfg.RpcClient, sharedParams.Output)
 		if err := validator.ValidateConfiguredEndpoints(ctx, cfg.GetActiveEndpoints()); err != nil {
 			return fmt.Errorf("preflight seed validation failed (try rerunning `generate`): %v", err)

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -47,16 +47,20 @@ func RunVegeta(
 			return fmt.Errorf("failed to load seed data: %v", err)
 		}
 		sharedParams = p
+
+		validator := parameters.NewEndpointSeedValidator(cfg.RpcClient, sharedParams.Output)
+		if err := validator.ValidateConfiguredEndpoints(ctx, cfg.GetActiveEndpoints()); err != nil {
+			return fmt.Errorf("preflight seed validation failed (try rerunning `generate`): %v", err)
+		}
 	}
 
 	// Construct endpoint blast configs
 	// 3... 2... 1...
 	var endpointBlasts []endpointBlast
-	var skippedEndpoints []string
 	for _, endpointKey := range cfg.GetEndpoints() {
 		rps := cfg.GetEndpointRPS(endpointKey)
 		if rps <= 0 {
-			skippedEndpoints = append(skippedEndpoints, endpointKey)
+			logger.Infof("Skipping endpoint: %v (RPS <= 0)", endpointKey)
 			continue
 		}
 
@@ -95,9 +99,6 @@ func RunVegeta(
 				MaxRPS:        rps,
 			},
 		})
-	}
-	if len(skippedEndpoints) > 0 {
-		logger.Infof("Skipping endpoints with RPS<=0: %v", skippedEndpoints)
 	}
 
 	// Fire!

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -44,13 +44,13 @@ func RunVegeta(
 	if cfg.InputDataPath != "" {
 		p, err := parameters.GetParameters(cfg.InputDataPath)
 		if err != nil {
-			return fmt.Errorf("failed to load seed data: %v", err)
+			return fmt.Errorf("failed to load seed data: %w", err)
 		}
 		sharedParams = p
 
 		// Run preflight validation to ensure seed data is fresh enough for the target RPC before blasting any endpoints
 		if err := sharedParams.ValidateConfiguredEndpoints(ctx, cfg.RpcClient, cfg.GetActiveEndpoints()); err != nil {
-			return fmt.Errorf("preflight seed validation failed (try rerunning `generate`): %v", err)
+			return fmt.Errorf("preflight seed validation failed (try rerunning `generate`): %w", err)
 		}
 	}
 
@@ -66,7 +66,7 @@ func RunVegeta(
 
 		paramMaps, err := parameters.BuildEndpointParams(endpointKey, sharedParams)
 		if err != nil {
-			return fmt.Errorf("couldn't build params for endpoint %s: %v", endpointKey, err)
+			return fmt.Errorf("couldn't build params for endpoint %s: %w", endpointKey, err)
 		}
 		bodies := make([][]byte, len(paramMaps))
 		for i, p := range paramMaps {
@@ -78,7 +78,7 @@ func RunVegeta(
 			}
 			bodies[i], err = json.Marshal(req)
 			if err != nil {
-				return fmt.Errorf("couldn't marshal request for endpoint %s: %v", endpointKey, err)
+				return fmt.Errorf("couldn't marshal request for endpoint %s: %w", endpointKey, err)
 			}
 		}
 		targeter := NewJSONRPCTargeter(cfg.RpcUrl, bodies)

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -49,8 +49,7 @@ func RunVegeta(
 		sharedParams = p
 
 		// Run preflight validation to ensure seed data is fresh enough for the target RPC before blasting any endpoints
-		validator := parameters.NewEndpointSeedValidator(cfg.RpcClient, sharedParams.Output)
-		if err := validator.ValidateConfiguredEndpoints(ctx, cfg.GetActiveEndpoints()); err != nil {
+		if err := sharedParams.ValidateConfiguredEndpoints(ctx, cfg.RpcClient, cfg.GetActiveEndpoints()); err != nil {
 			return fmt.Errorf("preflight seed validation failed (try rerunning `generate`): %v", err)
 		}
 	}

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -64,10 +64,10 @@ func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
 			a.logger.Info(a)
 		case <-ctx.Done():
 			if err := ctx.Err(); err != nil {
-				a.logger.Errorf("aggregator.Run terminating due to context error: %v", err)
+				a.logger.Error(fmt.Errorf("aggregator.Run terminating due to context error: %w", err))
 			}
 			if err := WriteOutput(a); err != nil {
-				a.logger.Error(fmt.Errorf("Failed to write output results: %v", err))
+				a.logger.Error(fmt.Errorf("Failed to write output results: %w", err))
 			}
 			return
 		}
@@ -151,7 +151,7 @@ func (a *Aggregator) String() string {
 
 	for _, endpointName := range a.orderedEndpoints {
 		endpointStats := a.stats[endpointName]
-		fmt.Fprintf(&line, "\n%-20s: %v", endpointName, endpointStats)
+		fmt.Fprintf(&line, "\n%-20s: %s", endpointName, endpointStats)
 	}
 
 	if elapsed >= a.duration {

--- a/internal/run/metrics/writer.go
+++ b/internal/run/metrics/writer.go
@@ -11,7 +11,7 @@ func WriteOutput(a *Aggregator) error {
 	if a.writeOutputPath != "" {
 		results := a.Results()
 		if writeErr := writeResultsJSON(results, a.writeOutputPath); writeErr != nil {
-			return fmt.Errorf("Failed to write results to %s: %v", a.writeOutputPath, writeErr)
+			return fmt.Errorf("Failed to write results to %s: %w", a.writeOutputPath, writeErr)
 		}
 		a.logger.Infof("Results written to %s", a.writeOutputPath)
 		return nil
@@ -22,16 +22,16 @@ func WriteOutput(a *Aggregator) error {
 // WriteResultsJSON writes the results to a JSON file
 func writeResultsJSON(results *Results, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("failed to create output directories for path %s: %v", path, err)
+		return fmt.Errorf("failed to create output directories for path %s: %w", path, err)
 	}
 
 	data, err := json.Marshal(results)
 	if err != nil {
-		return fmt.Errorf("failed to marshal results: %v", err)
+		return fmt.Errorf("failed to marshal results: %w", err)
 	}
 
 	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write results to %s: %v", path, err)
+		return fmt.Errorf("failed to write results to %s: %w", path, err)
 	}
 
 	return nil

--- a/internal/run/parameters/endpoints.go
+++ b/internal/run/parameters/endpoints.go
@@ -32,7 +32,7 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 
 	case "getLedgerEntries":
 		keys := params.Output.LedgerKeys
-		count := min(len(keys), util.DefaultPrebuiltBodies)
+		count := min(len(keys), util.DefaultNumPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			n := min(util.VaryKeyCount(), uint(len(keys)))
@@ -51,7 +51,7 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		if span <= 0 {
 			return nil, fmt.Errorf("empty ledger range for %s", endpointKey)
 		}
-		count := min(span, util.DefaultPrebuiltBodies)
+		count := min(span, util.DefaultNumPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			start := lr.First + uint32(rand.IntN(span))
@@ -70,7 +70,7 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		if span <= 0 {
 			return nil, fmt.Errorf("empty ledger range for %s", endpointKey)
 		}
-		count := min(span, util.DefaultPrebuiltBodies)
+		count := min(span, util.DefaultNumPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			start := lr.First + uint32(rand.IntN(span))
@@ -91,7 +91,7 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		}
 
 		eventBodies := params.Output.ContractEventData
-		count := util.DefaultPrebuiltBodies
+		count := util.DefaultNumPrebuiltBodies
 		result := make([]map[string]any, count)
 		for i := range count {
 			filters := eventBodies.BuildEventsFilters()

--- a/internal/run/parameters/endpoints.go
+++ b/internal/run/parameters/endpoints.go
@@ -24,23 +24,23 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		var result []map[string]any
 		for _, hash := range txs {
 			result = append(result, map[string]any{
-				"hash":   hash,
-				"format": util.VaryFormat(),
+				"hash":      hash,
+				"xdrFormat": util.VaryFormat(),
 			})
 		}
 		return result, nil
 
 	case "getLedgerEntries":
 		keys := params.Output.LedgerKeys
-		count := min(len(keys), 100)
+		count := min(len(keys), util.DefaultPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			n := min(util.VaryKeyCount(), uint(len(keys)))
 			// Pick n distinct random keys
 			keys := util.ChooseNAtRandom(keys, int(n))
 			result[i] = map[string]any{
-				"keys":   keys,
-				"format": util.VaryFormat(),
+				"keys":      keys,
+				"xdrFormat": util.VaryFormat(),
 			}
 		}
 		return result, nil
@@ -51,16 +51,15 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		if span <= 0 {
 			return nil, fmt.Errorf("empty ledger range for %s", endpointKey)
 		}
-		count := min(span, 100)
+		count := min(span, util.DefaultPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			start := lr.First + uint32(rand.IntN(span))
-			limit := util.VaryLimit(uint(util.TxPageLimit))
 			entry := map[string]any{
 				"startLedger": start,
-				"format":      util.VaryFormat(),
+				"xdrFormat":   util.VaryFormat(),
 			}
-			entry["pagination"] = setPaginationMap(limit, entry)
+			entry["pagination"] = setPaginationMap(start, entry, endpointKey)
 			result[i] = entry
 		}
 		return result, nil
@@ -71,23 +70,43 @@ func BuildEndpointParams(endpointKey string, params *Parameters) ([]map[string]a
 		if span <= 0 {
 			return nil, fmt.Errorf("empty ledger range for %s", endpointKey)
 		}
-		count := min(span, 100)
+		count := min(span, util.DefaultPrebuiltBodies)
 		result := make([]map[string]any, count)
 		for i := range count {
 			start := lr.First + uint32(rand.IntN(span))
-			limit := util.VaryLimit(uint(util.TxPageLimit))
 			entry := map[string]any{
 				"startLedger": start,
-				"format":      util.VaryFormat(),
+				"xdrFormat":   util.VaryFormat(),
 			}
-			entry["pagination"] = setPaginationMap(limit, entry)
+			entry["pagination"] = setPaginationMap(start, entry, endpointKey)
 			result[i] = entry
 		}
 		return result, nil
 
 	case "getEvents":
-		return nil, fmt.Errorf("getEvents endpoint not yet implemented")
+		lr := params.Output.LedgerRange
+		span := int(lr.Last - lr.First)
+		if span <= 0 {
+			return nil, fmt.Errorf("empty ledger range for %s", endpointKey)
+		}
 
+		eventBodies := params.Output.ContractEventData
+		count := util.DefaultPrebuiltBodies
+		result := make([]map[string]any, count)
+		for i := range count {
+			filters := eventBodies.BuildEventsFilters()
+			start := lr.First + uint32(rand.IntN(span))
+			end := start + uint32(rand.IntN(int(lr.Last-start))) + 1
+			entry := map[string]any{
+				"startLedger": start,
+				"endLedger":   end,
+				"xdrFormat":   util.VaryFormat(),
+				"filters":     []map[string]any{filters},
+			}
+			entry["pagination"] = setPaginationMap(start, entry, endpointKey)
+			result[i] = entry
+		}
+		return result, nil
 	default:
 		return nil, fmt.Errorf("unsupported endpoint %s", endpointKey)
 	}
@@ -105,7 +124,20 @@ func EndpointNeedsData(endpointKey string) (bool, error) {
 	}
 }
 
-func setPaginationMap(limit uint, entry map[string]any) map[string]any {
+func setPaginationMap(start uint32, entry map[string]any, endpoint string) map[string]any {
+	switch endpoint {
+	case "getTransactions", "getLedgers":
+		limit := util.VaryLimit(uint(util.TxPageLimit))
+		return setPaginationMapForTxAndLedgers(limit, entry)
+	case "getEvents":
+		limit := util.VaryLimit(uint(util.EventsPageLimit))
+		return setPaginationMapForEvents(start, limit, entry)
+	default:
+		return map[string]any{"limit": util.VaryLimit(uint(util.TxPageLimit))}
+	}
+}
+
+func setPaginationMapForTxAndLedgers(limit uint, entry map[string]any) map[string]any {
 	cursor := ""
 	if sl, ok := entry["startLedger"].(uint32); ok {
 		tidVal := toid.New(int32(sl), 1, 1).ToInt64() // build valid TOID cursor from the startLedger already in the entry
@@ -116,6 +148,19 @@ func setPaginationMap(limit uint, entry map[string]any) map[string]any {
 	if pagination.Cursor != "" {
 		paginationMap["cursor"] = pagination.Cursor
 		delete(entry, "startLedger") // cursor-based pagination omits startLedger
+	}
+	return paginationMap
+}
+
+func setPaginationMapForEvents(start uint32, limit uint, entry map[string]any) map[string]any {
+	cursor := fmt.Sprintf("%019d-%010d",
+		toid.New(int32(start), 1, 1).ToInt64(), 1)
+	pagination := util.VaryCursorBasedPaginationForEvents(limit, cursor)
+	paginationMap := map[string]any{"limit": pagination.Limit}
+	if pagination.Cursor != nil {
+		paginationMap["cursor"] = pagination.Cursor.String()
+		delete(entry, "startLedger")
+		delete(entry, "endLedger")
 	}
 	return paginationMap
 }

--- a/internal/run/parameters/load.go
+++ b/internal/run/parameters/load.go
@@ -17,7 +17,7 @@ type Parameters struct {
 func GetParameters(dataPath string) (*Parameters, error) {
 	output, err := loadParameters(dataPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load parameters: %v", err)
+		return nil, fmt.Errorf("failed to load parameters: %w", err)
 	}
 
 	params := &Parameters{
@@ -31,13 +31,13 @@ func GetParameters(dataPath string) (*Parameters, error) {
 func loadParameters(dataPath string) (seed.SeedData, error) {
 	f, err := os.Open(dataPath)
 	if err != nil {
-		return seed.SeedData{}, fmt.Errorf("couldn't open seed data file %s: %v", dataPath, err)
+		return seed.SeedData{}, fmt.Errorf("couldn't open seed data file %s: %w", dataPath, err)
 	}
 	defer f.Close()
 
 	var output seed.SeedData
 	if err := json.NewDecoder(f).Decode(&output); err != nil {
-		return seed.SeedData{}, fmt.Errorf("failed to decode seed data: %v", err)
+		return seed.SeedData{}, fmt.Errorf("failed to decode seed data: %w", err)
 	}
 	return output, nil
 }

--- a/internal/run/parameters/preflight_validate.go
+++ b/internal/run/parameters/preflight_validate.go
@@ -1,0 +1,69 @@
+package parameters
+
+import (
+	"context"
+	"fmt"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+
+	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
+)
+
+type endpointSeedValidationClient interface {
+	GetHealth(ctx context.Context) (protocol.GetHealthResponse, error)
+}
+
+type EndpointSeedValidator struct {
+	client   endpointSeedValidationClient
+	seedData seed.SeedData
+}
+
+func NewEndpointSeedValidator(client endpointSeedValidationClient, seedData seed.SeedData) *EndpointSeedValidator {
+	return &EndpointSeedValidator{client: client, seedData: seedData}
+}
+
+// ValidateConfiguredEndpoints runs seed freshness probes for the enabled endpoints
+// before run mode starts sending load.
+func (v *EndpointSeedValidator) ValidateConfiguredEndpoints(ctx context.Context, endpointKeys []string) error {
+	if v == nil || v.client == nil {
+		return nil
+	}
+
+	requiresSeedData := false
+	for _, endpointKey := range endpointKeys {
+		needsData, err := EndpointNeedsData(endpointKey)
+		if err != nil {
+			return fmt.Errorf("failed to determine whether endpoint %s needs seed data: %w", endpointKey, err)
+		}
+		if needsData {
+			requiresSeedData = true
+			break
+		}
+	}
+	if !requiresSeedData {
+		return nil
+	}
+
+	return v.validateRetentionWindow(ctx)
+}
+
+func (v *EndpointSeedValidator) validateRetentionWindow(ctx context.Context) error {
+	oldestSeedLedger := v.seedData.LedgerRange.First
+
+	resp, err := v.client.GetHealth(ctx)
+	if err != nil {
+		return fmt.Errorf("target RPC health check failed: %w", err)
+	}
+	if resp.LatestLedger == 0 {
+		return fmt.Errorf("target RPC health check did not report a latest ledger")
+	}
+	if oldestSeedLedger < resp.OldestLedger {
+		return fmt.Errorf(
+			"seed data start ledger %d is outside the RPC retention window [%d, %d]",
+			oldestSeedLedger,
+			resp.OldestLedger,
+			resp.LatestLedger,
+		)
+	}
+	return nil
+}

--- a/internal/run/parameters/preflight_validate.go
+++ b/internal/run/parameters/preflight_validate.go
@@ -5,27 +5,16 @@ import (
 	"fmt"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
-
-	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
 )
 
 type endpointSeedValidationClient interface {
 	GetHealth(ctx context.Context) (protocol.GetHealthResponse, error)
 }
 
-type EndpointSeedValidator struct {
-	client   endpointSeedValidationClient
-	seedData seed.SeedData
-}
-
-func NewEndpointSeedValidator(client endpointSeedValidationClient, seedData seed.SeedData) *EndpointSeedValidator {
-	return &EndpointSeedValidator{client: client, seedData: seedData}
-}
-
 // ValidateConfiguredEndpoints runs seed freshness probes for the enabled endpoints
 // before run mode starts sending load.
-func (v *EndpointSeedValidator) ValidateConfiguredEndpoints(ctx context.Context, endpointKeys []string) error {
-	if v == nil || v.client == nil {
+func (p *Parameters) ValidateConfiguredEndpoints(ctx context.Context, client endpointSeedValidationClient, endpointKeys []string) error {
+	if p == nil || client == nil {
 		return nil
 	}
 
@@ -44,13 +33,13 @@ func (v *EndpointSeedValidator) ValidateConfiguredEndpoints(ctx context.Context,
 		return nil
 	}
 
-	return v.validateRetentionWindow(ctx)
+	return p.validateRetentionWindow(ctx, client)
 }
 
-func (v *EndpointSeedValidator) validateRetentionWindow(ctx context.Context) error {
-	oldestSeedLedger := v.seedData.LedgerRange.First
+func (p *Parameters) validateRetentionWindow(ctx context.Context, client endpointSeedValidationClient) error {
+	oldestSeedLedger := p.Output.LedgerRange.First
 
-	resp, err := v.client.GetHealth(ctx)
+	resp, err := client.GetHealth(ctx)
 	if err != nil {
 		return fmt.Errorf("target RPC health check failed: %w", err)
 	}

--- a/internal/run/parameters/preflight_validate_test.go
+++ b/internal/run/parameters/preflight_validate_test.go
@@ -2,32 +2,60 @@ package parameters
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type preflightEndpointSeedValidationClient struct {
-	healthErr      error
-	healthResponse protocol.GetHealthResponse
+type jsonRPCRequest struct {
+	ID     any    `json:"id"`
+	Method string `json:"method"`
 }
 
-func (s *preflightEndpointSeedValidationClient) GetHealth(
-	_ context.Context,
-) (protocol.GetHealthResponse, error) {
-	return s.healthResponse, s.healthErr
+func newPreflightValidationClient(
+	t *testing.T,
+	healthResponse protocol.GetHealthResponse,
+) endpointSeedValidationClient {
+	t.Helper()
+
+	getHealthHttpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+
+		defer r.Body.Close()
+
+		var req jsonRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req)) // store r's body in req for assertion
+		require.Equal(t, protocol.GetHealthMethodName, req.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.ID,
+			"result":  healthResponse,
+		}))
+	})
+	server := httptest.NewServer(getHealthHttpHandler)
+	client := rpcclient.NewClient(server.URL, server.Client())
+	// close the server and client when the test finishes
+	t.Cleanup(func() {
+		server.Close()
+		require.NoError(t, client.Close())
+	})
+
+	return client
 }
 
 func TestValidatorChecksSeedStartForSeededEndpoints(t *testing.T) {
-	client := &preflightEndpointSeedValidationClient{
-		healthResponse: protocol.GetHealthResponse{
-			LatestLedger: 500,
-			OldestLedger: 100,
-		},
-	}
+	client := newPreflightValidationClient(t, protocol.GetHealthResponse{
+		LatestLedger: 500,
+		OldestLedger: 100,
+	})
 	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
 	err := params.ValidateConfiguredEndpoints(
@@ -35,11 +63,14 @@ func TestValidatorChecksSeedStartForSeededEndpoints(t *testing.T) {
 		client,
 		[]string{"getEvents"},
 	)
-	require.NoError(t, err)
+	require.NoError(t, err, "parameters are in the retention window, but validation failed")
 }
 
 func TestValidatorSkipsStaticEndpoints(t *testing.T) {
-	client := &preflightEndpointSeedValidationClient{}
+	client := newPreflightValidationClient(t, protocol.GetHealthResponse{
+		LatestLedger: 5000,
+		OldestLedger: 1000,
+	})
 	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
 	err := params.ValidateConfiguredEndpoints(
@@ -47,16 +78,14 @@ func TestValidatorSkipsStaticEndpoints(t *testing.T) {
 		client,
 		[]string{"getHealth", "getNetwork"},
 	)
-	require.NoError(t, err)
+	require.NoError(t, err, "data is stale, but static endpoints should be skipped")
 }
 
 func TestValidatorRejectsStaleStart(t *testing.T) {
-	client := &preflightEndpointSeedValidationClient{
-		healthResponse: protocol.GetHealthResponse{
-			LatestLedger: 400,
-			OldestLedger: 300,
-		},
-	}
+	client := newPreflightValidationClient(t, protocol.GetHealthResponse{
+		LatestLedger: 400,
+		OldestLedger: 300,
+	})
 	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 350}}}
 
 	err := params.ValidateConfiguredEndpoints(
@@ -65,15 +94,13 @@ func TestValidatorRejectsStaleStart(t *testing.T) {
 		[]string{"getEvents"},
 	)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "seed data start ledger 123 is outside the RPC retention window [300, 400]")
+	require.ErrorContains(t, err, "seed data start ledger 123 is outside the RPC retention window [300, 400]")
 }
 
 func TestValidatorRejectsMissingLatestLedger(t *testing.T) {
-	client := &preflightEndpointSeedValidationClient{
-		healthResponse: protocol.GetHealthResponse{
-			OldestLedger: 100,
-		},
-	}
+	client := newPreflightValidationClient(t, protocol.GetHealthResponse{
+		OldestLedger: 100,
+	})
 	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
 	err := params.ValidateConfiguredEndpoints(
@@ -82,5 +109,5 @@ func TestValidatorRejectsMissingLatestLedger(t *testing.T) {
 		[]string{"getLedgerEntries"},
 	)
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "target RPC health check did not report a latest ledger")
+	require.ErrorContains(t, err, "target RPC health check did not report a latest ledger")
 }

--- a/internal/run/parameters/preflight_validate_test.go
+++ b/internal/run/parameters/preflight_validate_test.go
@@ -28,10 +28,11 @@ func TestValidatorChecksSeedStartForSeededEndpoints(t *testing.T) {
 			OldestLedger: 100,
 		},
 	}
-	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
-	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+	err := params.ValidateConfiguredEndpoints(
 		context.Background(),
+		client,
 		[]string{"getEvents"},
 	)
 	require.NoError(t, err)
@@ -39,10 +40,11 @@ func TestValidatorChecksSeedStartForSeededEndpoints(t *testing.T) {
 
 func TestValidatorSkipsStaticEndpoints(t *testing.T) {
 	client := &preflightEndpointSeedValidationClient{}
-	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
-	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+	err := params.ValidateConfiguredEndpoints(
 		context.Background(),
+		client,
 		[]string{"getHealth", "getNetwork"},
 	)
 	require.NoError(t, err)
@@ -55,10 +57,11 @@ func TestValidatorRejectsStaleStart(t *testing.T) {
 			OldestLedger: 300,
 		},
 	}
-	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 350}}
+	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 350}}}
 
-	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+	err := params.ValidateConfiguredEndpoints(
 		context.Background(),
+		client,
 		[]string{"getEvents"},
 	)
 	require.Error(t, err)
@@ -71,10 +74,11 @@ func TestValidatorRejectsMissingLatestLedger(t *testing.T) {
 			OldestLedger: 100,
 		},
 	}
-	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+	params := &Parameters{Output: seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}}
 
-	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+	err := params.ValidateConfiguredEndpoints(
 		context.Background(),
+		client,
 		[]string{"getLedgerEntries"},
 	)
 	require.Error(t, err)

--- a/internal/run/parameters/preflight_validate_test.go
+++ b/internal/run/parameters/preflight_validate_test.go
@@ -1,0 +1,82 @@
+package parameters
+
+import (
+	"context"
+	"testing"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/stellar-rpc-blaster/internal/generate/seed"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type preflightEndpointSeedValidationClient struct {
+	healthErr      error
+	healthResponse protocol.GetHealthResponse
+}
+
+func (s *preflightEndpointSeedValidationClient) GetHealth(
+	_ context.Context,
+) (protocol.GetHealthResponse, error) {
+	return s.healthResponse, s.healthErr
+}
+
+func TestValidatorChecksSeedStartForSeededEndpoints(t *testing.T) {
+	client := &preflightEndpointSeedValidationClient{
+		healthResponse: protocol.GetHealthResponse{
+			LatestLedger: 500,
+			OldestLedger: 100,
+		},
+	}
+	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+
+	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+		context.Background(),
+		[]string{"getEvents"},
+	)
+	require.NoError(t, err)
+}
+
+func TestValidatorSkipsStaticEndpoints(t *testing.T) {
+	client := &preflightEndpointSeedValidationClient{}
+	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+
+	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+		context.Background(),
+		[]string{"getHealth", "getNetwork"},
+	)
+	require.NoError(t, err)
+}
+
+func TestValidatorRejectsStaleStart(t *testing.T) {
+	client := &preflightEndpointSeedValidationClient{
+		healthResponse: protocol.GetHealthResponse{
+			LatestLedger: 400,
+			OldestLedger: 300,
+		},
+	}
+	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 350}}
+
+	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+		context.Background(),
+		[]string{"getEvents"},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "seed data start ledger 123 is outside the RPC retention window [300, 400]")
+}
+
+func TestValidatorRejectsMissingLatestLedger(t *testing.T) {
+	client := &preflightEndpointSeedValidationClient{
+		healthResponse: protocol.GetHealthResponse{
+			OldestLedger: 100,
+		},
+	}
+	params := seed.SeedData{LedgerRange: seed.Range{First: 123, Last: 456}}
+
+	err := NewEndpointSeedValidator(client, params).ValidateConfiguredEndpoints(
+		context.Background(),
+		[]string{"getLedgerEntries"},
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "target RPC health check did not report a latest ledger")
+}

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -25,7 +25,7 @@ const (
 	MaxWorkers          = uint64(float64(PortCount) * PortAllocationRatio * WorkerMultiplier)
 
 	// Number of request bodies to pre-generate for data-dependent endpoints
-	DefaultPrebuiltBodies = int(1000)
+	DefaultNumPrebuiltBodies = int(1000)
 )
 
 // Data dependent endpoint limits and probabilities for run

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -23,6 +23,9 @@ const (
 	PortAllocationRatio = 0.60  // fraction of ports to use for connections (leaves 40% free for other processes)
 	WorkerMultiplier    = 2.5   // ratio for how many workers can share one connection
 	MaxWorkers          = uint64(float64(PortCount) * PortAllocationRatio * WorkerMultiplier)
+
+	// Number of request bodies to pre-generate for data-dependent endpoints
+	DefaultPrebuiltBodies = int(1000)
 )
 
 // Data dependent endpoint limits and probabilities for run
@@ -31,12 +34,4 @@ const (
 	LedgerKeyLimit         = 200
 	PrJson         float64 = 0.5 // probability of using "json" vs "xdr" format for transaction requests
 	PrCursor       float64 = 0.5 // probability of paginating with a cursor
-)
-
-// getEvents filter dimension probabilities
-const (
-	PrEventContractFilter float64 = 0.5 // probability of including contract ID(s) in an event filter
-	PrEventMultiContract  float64 = 0.5 // when contract filter is present, probability of multiple (2-5) vs single
-	PrEventTypeFilter     float64 = 0.5 // probability of including an event type filter
-	PrEventTopicFilter    float64 = 0.5 // probability of including a topic filter
 )

--- a/internal/util/request_builder.go
+++ b/internal/util/request_builder.go
@@ -4,6 +4,8 @@ import (
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
+// MakeGetTransactionsRequest builds a GetTransactionsRequest with the given start ledger or cursor.
+// Used for making generate mode requests to the getTransactions endpoint.
 func MakeGetTransactionsRequest(start uint32, cursor string) protocol.GetTransactionsRequest {
 	req := protocol.GetTransactionsRequest{
 		StartLedger: start,
@@ -18,6 +20,8 @@ func MakeGetTransactionsRequest(start uint32, cursor string) protocol.GetTransac
 	return req
 }
 
+// MakeGetEventsRequest builds a GetEventsRequest with the given start and end ledgers or cursor.
+// Used for making generate mode requests to the getEvents endpoint.
 func MakeGetEventsRequest(start uint32, end uint32, cursor *protocol.Cursor) protocol.GetEventsRequest {
 	req := protocol.GetEventsRequest{
 		StartLedger: start,

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -4,7 +4,6 @@ import (
 	"math/rand/v2"
 
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
-	"github.com/stellar/go-stellar-sdk/support/collections/set"
 )
 
 // VaryLimit returns a random limit between 1 and the provided max lVmit.
@@ -83,20 +82,17 @@ func ChooseNAtRandom[T any](items []T, n int) []T {
 	if n >= len(items) {
 		return items
 	}
-	chosen := set.NewSet[any](n)
-	result := make([]T, 0, n)
-	continuedCounter := 0
-	for len(chosen) < n {
-		item := items[rand.IntN(len(items))]
-		if chosen.Contains(item) {
-			continuedCounter++
-			if continuedCounter > n*10 { // safeguard against tiny sample size
-				break
-			}
-			continue
-		}
-		chosen.Add(item)
-		result = append(result, item)
+	indices := make([]int, len(items))
+	for i := range indices {
+		indices[i] = i
+	}
+	for i := range n {
+		j := i + rand.IntN(len(indices)-i)
+		indices[i], indices[j] = indices[j], indices[i]
+	}
+	result := make([]T, n)
+	for i := range n {
+		result[i] = items[indices[i]]
 	}
 	return result
 }

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -63,6 +63,22 @@ func VaryKeyCount() uint {
 	}
 }
 
+func VaryEventsFilter(contractIDs []string) map[string]any {
+	filter := make(map[string]any)
+	if len(contractIDs) > 0 && rand.Float64() < PrEventContractFilter {
+		if rand.Float64() < PrEventMultiContract {
+			n := 2 + rand.IntN(min(4, len(contractIDs)))
+			ids := ChooseNAtRandom(contractIDs, n)
+			filter["contractIds"] = ids
+		} else {
+			cid := contractIDs[rand.IntN(len(contractIDs))]
+			filter["contractIds"] = []string{cid}
+		}
+	}
+
+	return filter
+}
+
 func ChooseNAtRandom[T any](items []T, n int) []T {
 	if n >= len(items) {
 		return items

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -62,22 +62,6 @@ func VaryKeyCount() uint {
 	}
 }
 
-func VaryEventsFilter(contractIDs []string) map[string]any {
-	filter := make(map[string]any)
-	if len(contractIDs) > 0 && rand.Float64() < PrEventContractFilter {
-		if rand.Float64() < PrEventMultiContract {
-			n := 2 + rand.IntN(min(4, len(contractIDs)))
-			ids := ChooseNAtRandom(contractIDs, n)
-			filter["contractIds"] = ids
-		} else {
-			cid := contractIDs[rand.IntN(len(contractIDs))]
-			filter["contractIds"] = []string{cid}
-		}
-	}
-
-	return filter
-}
-
 func ChooseNAtRandom[T any](items []T, n int) []T {
 	if n >= len(items) {
 		return items
@@ -93,6 +77,36 @@ func ChooseNAtRandom[T any](items []T, n int) []T {
 	result := make([]T, n)
 	for i := range n {
 		result[i] = items[indices[i]]
+	}
+	return result
+}
+
+func WeightedChooseN[T any](items []T, weights []int, n int) []T {
+	if n >= len(items) {
+		return items
+	}
+	w := make([]int, len(weights))
+	copy(w, weights)
+
+	result := make([]T, 0, n)
+	for range n {
+		total := 0
+		for _, wt := range w {
+			total += wt
+		}
+		if total == 0 {
+			break
+		}
+		r := rand.IntN(total)
+		cumulative := 0
+		for i, wt := range w {
+			cumulative += wt
+			if r < cumulative {
+				result = append(result, items[i])
+				w[i] = 0
+				break
+			}
+		}
 	}
 	return result
 }

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -6,7 +6,7 @@ import (
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 )
 
-// VaryLimit returns a random limit between 1 and the provided max lVmit.
+// VaryLimit returns a random limit between 1 and the provided max limit.
 func VaryLimit(limitMax uint) uint {
 	return uint(rand.Float64()*float64(limitMax-1) + 1)
 }

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -64,6 +64,15 @@ func VaryKeyCount() uint {
 
 // This chooses N at random from T without replacement using the Fisher-Yates shuffle algorithm.
 func ChooseNAtRandom[T any](items []T, n int) []T {
+	return chooseNAtRandom(items, n, rand.IntN)
+}
+
+// ChooseNAtRandomSeeded is like ChooseNAtRandom but uses a caller-provided rand source for deterministic testing.
+func ChooseNAtRandomSeeded[T any](items []T, n int, rng *rand.Rand) []T {
+	return chooseNAtRandom(items, n, rng.IntN)
+}
+
+func chooseNAtRandom[T any](items []T, n int, intN func(int) int) []T {
 	if n >= len(items) {
 		return items
 	}
@@ -72,7 +81,7 @@ func ChooseNAtRandom[T any](items []T, n int) []T {
 		indices[i] = i
 	}
 	for i := range n {
-		j := i + rand.IntN(len(indices)-i)
+		j := i + intN(len(indices)-i)
 		indices[i], indices[j] = indices[j], indices[i]
 	}
 	result := make([]T, n)
@@ -82,9 +91,18 @@ func ChooseNAtRandom[T any](items []T, n int) []T {
 	return result
 }
 
-// This chooses N items from T without replacement according to the item weights
-// Does not replace so that filters don't have the same topic repeated
+// This chooses N items from T without replacement according to the item weights.
+// Does not replace so that filters don't have the same topic repeated.
 func WeightedChooseN[T any](items []T, weights []int, n int) []T {
+	return weightedChooseN(items, weights, n, rand.IntN)
+}
+
+// WeightedChooseNSeeded is like WeightedChooseN but uses a caller-provided rand source for deterministic testing.
+func WeightedChooseNSeeded[T any](items []T, weights []int, n int, rng *rand.Rand) []T {
+	return weightedChooseN(items, weights, n, rng.IntN)
+}
+
+func weightedChooseN[T any](items []T, weights []int, n int, intN func(int) int) []T {
 	if n >= len(items) {
 		return items
 	}
@@ -101,7 +119,7 @@ func WeightedChooseN[T any](items []T, weights []int, n int) []T {
 		if total == 0 {
 			break
 		}
-		r := rand.IntN(total)
+		r := intN(total)
 		cumulative := 0
 		for i, wt := range w {
 			cumulative += wt

--- a/internal/util/vary_parameters.go
+++ b/internal/util/vary_parameters.go
@@ -62,6 +62,7 @@ func VaryKeyCount() uint {
 	}
 }
 
+// This chooses N at random from T without replacement using the Fisher-Yates shuffle algorithm.
 func ChooseNAtRandom[T any](items []T, n int) []T {
 	if n >= len(items) {
 		return items
@@ -81,6 +82,8 @@ func ChooseNAtRandom[T any](items []T, n int) []T {
 	return result
 }
 
+// This chooses N items from T without replacement according to the item weights
+// Does not replace so that filters don't have the same topic repeated
 func WeightedChooseN[T any](items []T, weights []int, n int) []T {
 	if n >= len(items) {
 		return items
@@ -88,12 +91,13 @@ func WeightedChooseN[T any](items []T, weights []int, n int) []T {
 	w := make([]int, len(weights))
 	copy(w, weights)
 
+	total := 0
+	for _, wt := range w {
+		total += wt
+	}
+
 	result := make([]T, 0, n)
 	for range n {
-		total := 0
-		for _, wt := range w {
-			total += wt
-		}
 		if total == 0 {
 			break
 		}
@@ -101,8 +105,10 @@ func WeightedChooseN[T any](items []T, weights []int, n int) []T {
 		cumulative := 0
 		for i, wt := range w {
 			cumulative += wt
+			// If r is less than the cumulative weight, select this item
 			if r < cumulative {
 				result = append(result, items[i])
+				total -= w[i]
 				w[i] = 0
 				break
 			}

--- a/internal/util/vary_parameters_test.go
+++ b/internal/util/vary_parameters_test.go
@@ -1,0 +1,103 @@
+package util
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newSeededRand(seed uint64) *rand.Rand {
+	return rand.New(rand.NewPCG(seed, 0))
+}
+
+func TestChoosesCorrectCounts(t *testing.T) {
+	items := []string{"a", "b", "c"}
+	// Returns all when N greater or equal
+	result := ChooseNAtRandomSeeded(items, 5, newSeededRand(1))
+	assert.Equal(t, items, result)
+
+	// Returns correct count
+	result = ChooseNAtRandomSeeded(items, 3, newSeededRand(1))
+	assert.Equal(t, items, result)
+	assert.Len(t, result, 3)
+
+	// Weighted returns all when N greater or equal
+	weights := []int{10, 20, 30, 40}
+	result = WeightedChooseNSeeded(items, weights, 5, newSeededRand(1))
+	assert.Equal(t, items, result)
+
+	// Weighted returns correct count
+	result = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
+	assert.Len(t, result, 3)
+}
+
+func TestChooseNAtRandomDeterministicWithFixedSeed(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	first := ChooseNAtRandomSeeded(items, 3, newSeededRand(42))
+	second := ChooseNAtRandomSeeded(items, 3, newSeededRand(42))
+	assert.Equal(t, first, second)
+
+	// Weighted version is also deterministic
+	weights := []int{1, 2, 3, 4, 5}
+	first = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
+	second = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
+	assert.Equal(t, first, second)
+}
+
+func TestDistributionCoversAllItems(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	counts := make(map[string]int)
+	rng := newSeededRand(7)
+	runs := 1000
+	for range runs {
+		result := ChooseNAtRandomSeeded(items, 2, rng)
+		for _, v := range result {
+			counts[v]++
+		}
+	}
+	// Every item should be chosen at least once across 1000 runs of picking 2 from 5
+	for _, item := range items {
+		assert.Greater(t, counts[item], 0, "item %q was never chosen", item)
+	}
+}
+
+func TestWeightedChooseNZeroWeightNeverChosen(t *testing.T) {
+	items := []string{"a", "b", "c"}
+	weights := []int{50, 50, 0}
+	rng := newSeededRand(42)
+	for range 500 {
+		result := WeightedChooseNSeeded(items, weights, 2, rng)
+		for _, v := range result {
+			assert.NotEqual(t, "c", v, "zero-weight item should never be chosen")
+		}
+	}
+}
+
+func TestWeightedChooseN_RespectsWeightDistribution(t *testing.T) {
+	items := []string{"heavy", "medium", "light"}
+	weights := []int{100, 10, 1}
+	counts := make(map[string]int)
+	rng := newSeededRand(7)
+	runs := 1000
+	for range runs {
+		result := WeightedChooseNSeeded(items, weights, 1, rng)
+		counts[result[0]]++
+	}
+	// "heavy" (weight 100) should be picked far more than "light" (weight 1)
+	assert.Greater(t, counts["heavy"], counts["light"],
+		"heavy (w=100) should be chosen more often than light (w=1), got heavy=%d light=%d",
+		counts["heavy"], counts["light"])
+	assert.Greater(t, counts["heavy"], counts["medium"],
+		"heavy (w=100) should be chosen more often than medium (w=10), got heavy=%d medium=%d",
+		counts["heavy"], counts["medium"])
+}
+
+func TestWeightedChooseN_StopsEarlyWhenAllWeightsExhausted(t *testing.T) {
+	items := []string{"a", "b", "c", "d"}
+	weights := []int{1, 0, 0, 0}
+	result := WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
+	// Only "a" has nonzero weight, so we can only pick 1 item
+	assert.Len(t, result, 1)
+	assert.Equal(t, "a", result[0])
+}

--- a/internal/util/vary_parameters_test.go
+++ b/internal/util/vary_parameters_test.go
@@ -47,7 +47,7 @@ func TestChooseNAtRandomDeterministicWithFixedSeed(t *testing.T) {
 
 func TestDistributionCoversAllItems(t *testing.T) {
 	items := []string{"a", "b", "c", "d", "e"}
-	counts := make(map[string]int)
+	counts := map[string]int{}
 	rng := newSeededRand(7)
 	runs := 1000
 	for range runs {
@@ -77,7 +77,7 @@ func TestWeightedChooseNZeroWeightNeverChosen(t *testing.T) {
 func TestWeightedChooseN_RespectsWeightDistribution(t *testing.T) {
 	items := []string{"heavy", "medium", "light"}
 	weights := []int{100, 10, 1}
-	counts := make(map[string]int)
+	counts := map[string]int{}
 	rng := newSeededRand(7)
 	runs := 1000
 	for range runs {

--- a/internal/util/vary_parameters_test.go
+++ b/internal/util/vary_parameters_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand/v2"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newSeededRand(seed uint64) *rand.Rand {
@@ -15,34 +15,46 @@ func TestChoosesCorrectCounts(t *testing.T) {
 	items := []string{"a", "b", "c"}
 	// Returns all when N greater or equal
 	result := ChooseNAtRandomSeeded(items, 5, newSeededRand(1))
-	assert.Equal(t, items, result)
+	require.Equal(t, items, result)
 
 	// Returns correct count
 	result = ChooseNAtRandomSeeded(items, 3, newSeededRand(1))
-	assert.Equal(t, items, result)
-	assert.Len(t, result, 3)
+	require.Equal(t, items, result)
+	require.Len(t, result, 3)
 
 	// Weighted returns all when N greater or equal
 	weights := []int{10, 20, 30, 40}
 	result = WeightedChooseNSeeded(items, weights, 5, newSeededRand(1))
-	assert.Equal(t, items, result)
+	require.Equal(t, items, result)
 
 	// Weighted returns correct count
 	result = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
-	assert.Len(t, result, 3)
+	require.Len(t, result, 3)
 }
 
 func TestChooseNAtRandomDeterministicWithFixedSeed(t *testing.T) {
 	items := []string{"a", "b", "c", "d", "e"}
 	first := ChooseNAtRandomSeeded(items, 3, newSeededRand(42))
 	second := ChooseNAtRandomSeeded(items, 3, newSeededRand(42))
-	assert.Equal(t, first, second)
+	require.Equal(t, first, second)
 
 	// Weighted version is also deterministic
 	weights := []int{1, 2, 3, 4, 5}
 	first = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
 	second = WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
-	assert.Equal(t, first, second)
+	require.Equal(t, first, second)
+}
+
+func TestChooseNAtRandomStableSelectionsForFixedSeed(t *testing.T) {
+	items := []string{"a", "b", "c", "d", "e"}
+	weights := []int{1, 2, 3, 4, 5}
+
+	// Only applies for seed 42
+	ChooseNAtRandomSeededWithFixedSeed := []string{"e", "b", "c"}
+	WeightedChooseNSeededWithFixedSeed := []string{"e", "d", "a"}
+	// breaks if the algorithm behind ChooseNAtRandomSeeded or WeightedChooseNSeeded changes
+	require.Equal(t, ChooseNAtRandomSeededWithFixedSeed, ChooseNAtRandomSeeded(items, 3, newSeededRand(42)))
+	require.Equal(t, WeightedChooseNSeededWithFixedSeed, WeightedChooseNSeeded(items, weights, 3, newSeededRand(42)))
 }
 
 func TestDistributionCoversAllItems(t *testing.T) {
@@ -58,7 +70,7 @@ func TestDistributionCoversAllItems(t *testing.T) {
 	}
 	// Every item should be chosen at least once across 1000 runs of picking 2 from 5
 	for _, item := range items {
-		assert.Greater(t, counts[item], 0, "item %q was never chosen", item)
+		require.Greater(t, counts[item], 0, "item %q was never chosen", item)
 	}
 }
 
@@ -69,7 +81,7 @@ func TestWeightedChooseNZeroWeightNeverChosen(t *testing.T) {
 	for range 500 {
 		result := WeightedChooseNSeeded(items, weights, 2, rng)
 		for _, v := range result {
-			assert.NotEqual(t, "c", v, "zero-weight item should never be chosen")
+			require.NotEqual(t, "c", v, "zero-weight item should never be chosen")
 		}
 	}
 }
@@ -85,10 +97,10 @@ func TestWeightedChooseN_RespectsWeightDistribution(t *testing.T) {
 		counts[result[0]]++
 	}
 	// "heavy" (weight 100) should be picked far more than "light" (weight 1)
-	assert.Greater(t, counts["heavy"], counts["light"],
+	require.Greater(t, counts["heavy"], counts["light"],
 		"heavy (w=100) should be chosen more often than light (w=1), got heavy=%d light=%d",
 		counts["heavy"], counts["light"])
-	assert.Greater(t, counts["heavy"], counts["medium"],
+	require.Greater(t, counts["heavy"], counts["medium"],
 		"heavy (w=100) should be chosen more often than medium (w=10), got heavy=%d medium=%d",
 		counts["heavy"], counts["medium"])
 }
@@ -98,6 +110,6 @@ func TestWeightedChooseN_StopsEarlyWhenAllWeightsExhausted(t *testing.T) {
 	weights := []int{1, 0, 0, 0}
 	result := WeightedChooseNSeeded(items, weights, 3, newSeededRand(42))
 	// Only "a" has nonzero weight, so we can only pick 1 item
-	assert.Len(t, result, 1)
-	assert.Equal(t, "a", result[0])
+	require.Len(t, result, 1)
+	require.Equal(t, "a", result[0])
 }


### PR DESCRIPTION
### What
Adds support for creating parameter bodies for the `getEvents` endpoint from the seed data created by the `generate` command (#5).

Additionally, it introduces a minor preflight check to ensure that the seed data created in `generate` is not stale prior to a load test/`run` execution that includes data-dependent endpoints.

### Why
This is the final data-dependent endpoint that must be supported by `stellar-rpc-blaster`. It requires significantly more processing and design consideration to create representative endpoint blasts than the others.

The filter builder designed here seeks to make filters of the following shapes:
- `{ contractIds: [ "C..." ]}`
- `{ contractIds: [ "C..." ], topics: [ [ "transfer" ] }`
- `{ contractIds: [ "C..." ], topics: [ [ "transfer", "G..." ] }`
- `{ contractIds: [ "C..." ], topics: [ [ "transfer", "G..." ], [ "mint" ] },`
- `{ contractIds: [ "C..." ], topics: [ [ "transfer", "G..." ], [ "mint", "G..." ] }`
- `{ contractIds: [ "CA...", "CB..." ], topics: [ [ "transfer" ] }`

For a given filter `{ contractIds: [ <C1>, <C2>, ... ], topics: [ [ <T1>, <P11, P12, ... > ], [ <T2>, <P21, P22, ... > ] }`, key design features of the filter builder include:
- uniform `Ci`/contract ID selection, with 0-5 contract IDs selected
- per-contract topic-selection, with 0-5 draws weighted by the frequency of the topic observed
- between 0 and 4 positionally-dependent `Pij`/"parameter topics" chosen from the selected topic. (i.e. given `Ti`, among the topics `Pij` that follow `Ti` in the event response, at most, [Pi1, Pi2, Pi3, Pi4] will be selected)

The preflight check was added because previously, stale requests would not be trivially detectable (considering this is not necessarily an error path on an endpoint request path), leading to load tests that could execute with stale data. This is a fast-fail check done based on the RPC's `Oldest_Ledger` and the seed data's `ledger_range.first`.

### Known limitations
N/A