### PR TITLE
Add start RPS ramp-up parameter to toml

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -131,7 +131,7 @@ func (a *App) runLoadTest(ctx context.Context) error {
 		aggregator.Run(ctx, out)
 	})
 
-	be.Run(ctx, a.logger) // run blasts and block until done
+	be.Run(ctx, a.logger, aggregator) // run blasts and block until done
 	close(out)
 	wg.Wait()
 

--- a/internal/config/config.example.toml
+++ b/internal/config/config.example.toml
@@ -7,34 +7,37 @@
 # Using the default seed data output path, this is "./output/seed.json" 
 input_data_path = "./output/pubnet-seed.json"
 
-# No-parameter/run-only endpoints
-[endpoints.getHealth]
-rps = 20
+# # No-parameter/run-only endpoints
+# [endpoints.getHealth]
+# rps = 20
 
 [endpoints.getNetwork]
 rps = 20
+start_rps = 12
 
 [endpoints.getVersionInfo]
 rps = 20
 
 [endpoints.getLatestLedger]
 rps = 20
+start_rps = 10
 
 [endpoints.getFeeStats]
 rps = 20
 
 # Parameter-based/generate-required endpoints
 [endpoints.getEvents]
-rps = 20
+rps = 1
 
 [endpoints.getLedgerEntries]
 rps = 20
+start_rps = 10
 
 # [endpoints.getLedgers]
 # rps = 20
 
-# [endpoints.getTransaction]
-# rps = 20
+[endpoints.getTransaction]
+rps = 20
 
-# [endpoints.getTransactions]
-# rps = 20
+[endpoints.getTransactions]
+rps = 10

--- a/internal/config/configs.go
+++ b/internal/config/configs.go
@@ -81,7 +81,8 @@ type RuntimeSettings struct {
 
 // Per-endpoint configuration
 type EndpointConfig struct {
-	RPS int `toml:"rps"` // requests per second
+	RPS      int `toml:"rps"`                 // requests per second
+	StartRPS int `toml:"start_rps,omitempty"` // initial RPS to start at, must be <= RPS
 }
 
 func NewConfig(
@@ -151,6 +152,7 @@ func (c *Config) processToml(tomlPath string) error {
 // Ensure at least one endpoint is configured if launching a load test and data-dependent endpoints have input data
 func (c *Config) validateEndpointConfig() error {
 	hasValidEndpoint := false
+	hasStartRPS := false
 	for _, endpoint := range c.GetActiveEndpoints() {
 		hasValidEndpoint = true
 		if needs, err := parameters.EndpointNeedsData(endpoint); err != nil {
@@ -158,9 +160,19 @@ func (c *Config) validateEndpointConfig() error {
 		} else if needs && c.InputDataPath == "" {
 			return fmt.Errorf("endpoint %s requires input data, but no input-data-path was provided", endpoint)
 		}
+
+		if c.GetEndpointTargetRPS(endpoint) < c.GetEndpointStartRPS(endpoint) {
+			return fmt.Errorf("could not parse endpoint %s, need start_rps <= rps", endpoint)
+		}
+		if c.GetEndpointStartRPS(endpoint) > 1 {
+			hasStartRPS = true
+		}
 	}
 	if !hasValidEndpoint {
 		return fmt.Errorf("at least one endpoint must be configured with RPS > 0")
+	}
+	if hasStartRPS && c.RampUp == 0 {
+		return fmt.Errorf("at least one endpoint is configured with start_rps > 0, but ramp-up duration is not set")
 	}
 	return nil
 }
@@ -169,18 +181,25 @@ func (c *Config) GetEndpoints() []string {
 	return slices.Collect(maps.Keys(c.Endpoints))
 }
 
-func (c *Config) GetEndpointRPS(key string) int {
+func (c *Config) GetEndpointTargetRPS(key string) int {
 	if ep, ok := c.Endpoints[key]; ok {
 		return ep.RPS
 	}
 	return 0
 }
 
+func (c *Config) GetEndpointStartRPS(key string) int {
+	if ep, ok := c.Endpoints[key]; ok {
+		return max(ep.StartRPS, 1)
+	}
+	return 1
+}
+
 // GetActiveEndpoints returns the endpoints configured with RPS > 0.
 func (c *Config) GetActiveEndpoints() []string {
 	activeEndpoints := make([]string, 0, len(c.Endpoints))
 	for _, endpointKey := range c.GetEndpoints() {
-		if c.GetEndpointRPS(endpointKey) > 0 {
+		if c.GetEndpointTargetRPS(endpointKey) > 0 {
 			activeEndpoints = append(activeEndpoints, endpointKey)
 		}
 	}

--- a/internal/run/engine/pacer.go
+++ b/internal/run/engine/pacer.go
@@ -15,10 +15,10 @@ type RampToConstantPacer struct {
 	TotalDuration time.Duration
 }
 
-func NewRampToConstantPacer(startRPS, maxRPS int, cfg config.Config) RampToConstantPacer {
+func NewRampToConstantPacer(endpointKey string, cfg config.Config) RampToConstantPacer {
 	return RampToConstantPacer{
-		StartRPS:      startRPS,
-		MaxRPS:        maxRPS,
+		StartRPS:      cfg.GetEndpointStartRPS(endpointKey),
+		MaxRPS:        cfg.GetEndpointTargetRPS(endpointKey),
 		RampDuration:  cfg.RampUp,
 		TotalDuration: cfg.Duration,
 	}

--- a/internal/run/engine/pacer.go
+++ b/internal/run/engine/pacer.go
@@ -15,9 +15,9 @@ type RampToConstantPacer struct {
 	TotalDuration time.Duration
 }
 
-func NewRampToConstantPacer(maxRPS int, cfg config.Config) RampToConstantPacer {
+func NewRampToConstantPacer(startRPS, maxRPS int, cfg config.Config) RampToConstantPacer {
 	return RampToConstantPacer{
-		StartRPS:      1,
+		StartRPS:      startRPS,
 		MaxRPS:        maxRPS,
 		RampDuration:  cfg.RampUp,
 		TotalDuration: cfg.Duration,

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -61,8 +61,8 @@ func NewBlastEngine(
 	// Construct each endpoint's blast config
 	var endpointBlasts []EndpointBlastConfig
 	for _, endpointKey := range cfg.GetActiveEndpoints() {
-		rps := cfg.GetEndpointRPS(endpointKey)
-		pacer := NewRampToConstantPacer(rps, cfg)
+		startRps, targetRps := cfg.GetEndpointStartRPS(endpointKey), cfg.GetEndpointTargetRPS(endpointKey)
+		pacer := NewRampToConstantPacer(startRps, targetRps, cfg)
 
 		maxNumBodies := pacer.Hits(cfg.Duration) // upper limit of how many request bodies we could possibly need
 		paramMaps, err := parameters.BuildEndpointParams(endpointKey, int(maxNumBodies), sharedParams)
@@ -102,19 +102,24 @@ func NewBlastEngine(
 }
 
 // Run executes the blast according to the engine's configuration, sending results to the OutCh for aggregation
-func (b *BlastEngine) Run(ctx context.Context, logger *log.Entry) {
+func (b *BlastEngine) Run(ctx context.Context, logger *log.Entry, aggregator *blasterMetrics.Aggregator) {
 	if b.cfg.Serial {
 		for _, blast := range b.BlastSpecs {
 			if ctx.Err() != nil {
 				logger.Errorf("Endpoint blasts terminating early due to context error: %s", ctx.Err().Error())
 				return
 			}
+			aggregator.ActivateEndpoint(blast.EndpointKey)
 			logger.Infof("Serial mode: starting endpoint %s", blast.EndpointKey)
+			logger.Infof("%s", aggregator) // print progress with new endpoint activated
+
 			epCtx, epCancel := context.WithTimeout(ctx, b.cfg.Duration)
 			blastAtEndpoint(epCtx, blast, b.blastFn, b.outCh)
 			epCancel()
 		}
 	} else {
+		logger.Infof("%s", aggregator) // print initial 0-sample stats
+
 		ctx, cancel := context.WithTimeout(ctx, b.cfg.Duration)
 		defer cancel()
 		var wg sync.WaitGroup

--- a/internal/run/engine/run.go
+++ b/internal/run/engine/run.go
@@ -61,8 +61,7 @@ func NewBlastEngine(
 	// Construct each endpoint's blast config
 	var endpointBlasts []EndpointBlastConfig
 	for _, endpointKey := range cfg.GetActiveEndpoints() {
-		startRps, targetRps := cfg.GetEndpointStartRPS(endpointKey), cfg.GetEndpointTargetRPS(endpointKey)
-		pacer := NewRampToConstantPacer(startRps, targetRps, cfg)
+		pacer := NewRampToConstantPacer(endpointKey, cfg)
 
 		maxNumBodies := pacer.Hits(cfg.Duration) // upper limit of how many request bodies we could possibly need
 		paramMaps, err := parameters.BuildEndpointParams(endpointKey, int(maxNumBodies), sharedParams)

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -170,6 +170,8 @@ func (a *Aggregator) Record(sample Sample) error {
 }
 
 func (a *Aggregator) ActivateEndpoint(endpointKey string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.stats[endpointKey].isActive = true
 }
 

--- a/internal/run/metrics/aggregator.go
+++ b/internal/run/metrics/aggregator.go
@@ -34,20 +34,20 @@ type Aggregator struct {
 
 // EndpointStats collects stats for all vegeta workers of an endpoint
 type EndpointStats struct {
-	histogram         *hdrhistogram.Histogram
-	success           uint64
-	errors            uint64
-	errorTypes        map[string]ErrorResult
-	percentiles       map[float64]time.Duration
-	targetRPS         float64
-	duration          time.Duration // configured run duration for this endpoint
-	startTime time.Time // set on first sample (fixes serial mode)
+	histogram   *hdrhistogram.Histogram
+	success     uint64
+	errors      uint64
+	errorTypes  map[string]ErrorResult
+	percentiles map[float64]time.Duration
+	startRPS    float64
+	targetRPS   float64
+	duration    time.Duration // configured run duration for this endpoint
+	startTime   time.Time     // set on first sample (fixes serial mode)
+	isActive    bool          // for serial mode, indicates if endpoint has been activated yet
 }
 
 // Main driver function; consumes samples from the channel and prints progress every 5 seconds.
 func (a *Aggregator) Run(ctx context.Context, in <-chan Sample) {
-	a.start = time.Now()
-
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
@@ -90,6 +90,7 @@ func NewAggregator(logger *log.Entry, settings config.Config) *Aggregator {
 	a := Aggregator{
 		logger:          logger,
 		stats:           make(map[string]*EndpointStats),
+		start:           time.Now(),
 		duration:        duration,
 		writeOutputPath: settings.TestOutputPath,
 	}
@@ -102,6 +103,10 @@ func NewAggregator(logger *log.Entry, settings config.Config) *Aggregator {
 			percentiles: make(map[float64]time.Duration),
 			errorTypes:  make(map[string]ErrorResult),
 			duration:    settings.Duration,
+			startRPS:    float64(settings.GetEndpointStartRPS(endpointKey)),
+		}
+		if !settings.Serial {
+			a.stats[endpointKey].isActive = true // in non-serial mode, all endpoints are active from the start
 		}
 	}
 
@@ -164,6 +169,10 @@ func (a *Aggregator) Record(sample Sample) error {
 	return nil
 }
 
+func (a *Aggregator) ActivateEndpoint(endpointKey string) {
+	a.stats[endpointKey].isActive = true
+}
+
 // constructs a logging string showing progress for all endpoints
 func (a *Aggregator) String() string {
 	if a.done {
@@ -180,12 +189,11 @@ func (a *Aggregator) String() string {
 
 	for _, endpointName := range a.orderedEndpoints {
 		endpointStats := a.stats[endpointName]
-		if endpointStats.targetRPS == 0 {
-			continue
+		if endpointStats.isActive {
+			fmt.Fprintf(&line, "\n%-20s: %s", endpointName, endpointStats)
 		}
-		fmt.Fprintf(&line, "\n%-20s: %s", endpointName, endpointStats)
 	}
-
+	line.WriteString("\n")
 	if elapsed >= a.duration {
 		a.done = true
 	}
@@ -197,12 +205,16 @@ func (a *Aggregator) String() string {
 func (e *EndpointStats) String() string {
 	e.refreshPercentiles()
 	total := e.success + e.errors
+	rps := e.targetRPS
 
 	var pctOK float64
 	if total > 0 {
 		pctOK = float64(e.success) / float64(total) * 100
+	} else {
+		// if no samples yet, show start RPS to indicate starting point
+		rps = e.startRPS
 	}
-	out := fmt.Sprintf("%6d resp (%6d ok, %4d err) %5.1f%% ok | %6.1f target RPS | ", total, e.success, e.errors, pctOK, e.targetRPS)
+	out := fmt.Sprintf("%6d resp (%6d ok, %4d err) %5.1f%% ok | %6.1f target RPS | ", total, e.success, e.errors, pctOK, rps)
 	for _, p := range capturedPercentiles {
 		out += fmt.Sprintf("p%4.1f: %8s, ", p, fmtDuration(e.percentiles[p]))
 	}


### PR DESCRIPTION
### What

Adds an optional per-endpoint `start_rps` field to the TOML config, allowing ramp-ups to begin from a value other than `1`.
```toml
[endpoint.ENDPOINT1_NAME]
rps = X
start_rps = Y

[endpoint.ENDPOINT10_NAME]
rps = Z
# no start_rps specified -- defaults to 1
```
Note the following behaviors of this parameter:
- `start_rps` requires `--ramp-up` to be set; errors otherwise.
- `start_rps` must be less than or equal to the target RPS; errors otherwise.
- Defaults to `1` when omitted, preserving current behavior.

This PR also makes minor changes to the aggregator's log printing. In particular, it now has a "pre-blast" print (either once for a concurrent blast, or at the start of each endpoint blast in serial mode). This shows us the RPS values we are starting from for each endpoint rather _just_ than the RPS values each endpoint is at after `>= 5` seconds of that endpoint blast.

### Why

Currently, every blast ramps from `0` to `target_rps`, forcing us to re-traverse known-ok RPS ranges when trying to narrow down where an endpoint buckles. For example, if we know it buckles between `300-500 RPS`, we can't ramp from `300` to `500` directly -- we have to start from `0` every time.

For the live logs enhancement, formerly, each endpoint always started at `1` RPS, so it didn't matter much if we had an initial log printed at 0 requests. Now that endpoints can start at any RPS, it's helpful to see where the endpoint is starting from rather than where it's at 5 seconds into the run.

### Known Limitations
N/A