### PR TITLE
tx-load-test: per-tx fee jitter and bad_seq recovery

### DIFF
--- a/cmd/tx-load-test/benchmark/runner_attack.go
+++ b/cmd/tx-load-test/benchmark/runner_attack.go
@@ -112,14 +112,34 @@ func (s *attackState) handleSendTransactionEnvelope(envelope sendRespEnvelope, s
 		return true
 	case "ERROR":
 		atomic.AddUint64(&s.submitErrors, 1)
-		s.errorCodes.inc(ledger.DecodeTransactionResultCode(envelope.Result.ErrorResultXDR))
-		for _, opResult := range txstate.DecodeOperationResults(envelope.Result.ErrorResultXDR) {
-			s.submitOpResults.inc(opResult)
+		// Decode the error XDR once and feed the parsed result to all the
+		// helpers that need it. Under heavy rejection rates this avoids three
+		// SafeUnmarshalBase64 calls per submitted tx.
+		var (
+			code     = "unknown"
+			isBadSeq bool
+		)
+		if result, ok := ledger.DecodeTxResult(envelope.Result.ErrorResultXDR); ok {
+			code = ledger.ResultCodeFromTxResult(&result)
+			for _, opResult := range txstate.OperationResultsFromTxResult(&result) {
+				s.submitOpResults.inc(opResult)
+			}
+			isBadSeq = ledger.IsBadSeqFromTxResult(&result)
+		} else if envelope.Result.ErrorResultXDR != "" {
+			code = "decode-error"
 		}
+		s.errorCodes.inc(code)
 		if summary := summarizeDiagnosticEvents(envelope.Result.DiagnosticEventsXDR); summary != "" {
 			s.submitDiagnostics.inc(summary)
 		}
-		releaseRetryable(accounts, envelope.ID)
+		if isBadSeq {
+			// Cached seq is out of sync with chain. Rolling back and retrying
+			// the same seq just reproduces the error, so route through recovery
+			// to reload chain truth before this account is reused.
+			releaseAmbiguous(accounts, envelope.ID)
+		} else {
+			releaseRetryable(accounts, envelope.ID)
+		}
 		return true
 	default:
 		atomic.AddUint64(&s.ambiguous, 1)

--- a/cmd/tx-load-test/benchmark/runner_test.go
+++ b/cmd/tx-load-test/benchmark/runner_test.go
@@ -266,9 +266,42 @@ func TestPercentileDurationEdges(t *testing.T) {
 	require.Equal(t, 2*time.Second, percentileDuration(values, 0.5))
 }
 
+// txResultErrorXDR builds a base64-encoded TransactionResult XDR with the
+// given outer code and (optionally) inner code. Used to drive the ERROR
+// branch of handleSendTransactionEnvelope with realistic result XDRs.
+func txResultErrorXDR(t *testing.T, outer xdr.TransactionResultCode, inner *xdr.TransactionResultCode) string {
+	t.Helper()
+	r := xdr.TransactionResult{}
+	switch outer {
+	case xdr.TransactionResultCodeTxFeeBumpInnerSuccess, xdr.TransactionResultCodeTxFeeBumpInnerFailed:
+		require.NotNil(t, inner)
+		innerRR := xdr.InnerTransactionResultResult{Code: *inner}
+		switch *inner {
+		case xdr.TransactionResultCodeTxSuccess, xdr.TransactionResultCodeTxFailed:
+			empty := []xdr.OperationResult{}
+			innerRR.Results = &empty
+		}
+		pair := xdr.InnerTransactionResultPair{
+			Result: xdr.InnerTransactionResult{Result: innerRR},
+		}
+		r.Result = xdr.TransactionResultResult{Code: outer, InnerResultPair: &pair}
+	default:
+		require.Nil(t, inner)
+		r.Result = xdr.TransactionResultResult{Code: outer}
+	}
+	b64, err := xdr.MarshalBase64(r)
+	require.NoError(t, err)
+	return b64
+}
+
 func TestHandleSendTransactionEnvelopeTracksStatuses(t *testing.T) {
 	state := newAttackState(4)
 	leases := &fakeLeaseManager{}
+
+	innerBadSeq := xdr.TransactionResultCodeTxBadSeq
+	badSeqDirect := txResultErrorXDR(t, xdr.TransactionResultCodeTxBadSeq, nil)
+	badSeqWrapped := txResultErrorXDR(t, xdr.TransactionResultCodeTxFeeBumpInnerFailed, &innerBadSeq)
+	insufficientFee := txResultErrorXDR(t, xdr.TransactionResultCodeTxInsufficientFee, nil)
 
 	require.True(t, state.handleSendTransactionEnvelope(sendRespEnvelope{
 		ID: 11,
@@ -288,6 +321,7 @@ func TestHandleSendTransactionEnvelopeTracksStatuses(t *testing.T) {
 		ID:     12,
 		Result: protocol.SendTransactionResponse{Status: "TRY_AGAIN_LATER"},
 	}, time.Unix(2, 0), leases))
+	// ERROR with non-decodable XDR routes to retryable (default ERROR path).
 	require.True(t, state.handleSendTransactionEnvelope(sendRespEnvelope{
 		ID:     13,
 		Result: protocol.SendTransactionResponse{Status: "ERROR", ErrorResultXDR: "AAAA"},
@@ -296,14 +330,32 @@ func TestHandleSendTransactionEnvelopeTracksStatuses(t *testing.T) {
 		ID:     14,
 		Result: protocol.SendTransactionResponse{Status: "UNKNOWN"},
 	}, time.Unix(4, 0), leases))
+	// ERROR with a tx_bad_seq result XDR routes to ambiguous (recovery), not
+	// retryable, so the cached seq is reloaded from chain instead of looping
+	// on the same wrong seq.
+	require.True(t, state.handleSendTransactionEnvelope(sendRespEnvelope{
+		ID:     15,
+		Result: protocol.SendTransactionResponse{Status: "ERROR", ErrorResultXDR: badSeqDirect},
+	}, time.Unix(5, 0), leases))
+	// Same for tx_fee_bump_inner_failed wrapping tx_bad_seq.
+	require.True(t, state.handleSendTransactionEnvelope(sendRespEnvelope{
+		ID:     16,
+		Result: protocol.SendTransactionResponse{Status: "ERROR", ErrorResultXDR: badSeqWrapped},
+	}, time.Unix(6, 0), leases))
+	// ERROR with a non-bad_seq decodable XDR (e.g. insufficient_fee) still
+	// routes to retryable.
+	require.True(t, state.handleSendTransactionEnvelope(sendRespEnvelope{
+		ID:     17,
+		Result: protocol.SendTransactionResponse{Status: "ERROR", ErrorResultXDR: insufficientFee},
+	}, time.Unix(7, 0), leases))
 
 	_, _, queued, tryAgainLater, submitErrors, ambiguous := state.submissionSnapshot()
 	require.Equal(t, uint64(1), queued)
 	require.Equal(t, uint64(1), tryAgainLater)
-	require.Equal(t, uint64(1), submitErrors)
-	require.Equal(t, uint64(1), ambiguous)
-	require.Equal(t, []int64{12, 13}, leases.retryableReleases)
-	require.Equal(t, []int64{14}, leases.ambiguousReleases)
+	require.Equal(t, uint64(4), submitErrors) // IDs 13, 15, 16, 17.
+	require.Equal(t, uint64(1), ambiguous)    // submit-time ambiguous counter only — bad_seq routing uses ReleaseAmbiguous but doesn't bump this counter directly.
+	require.Equal(t, []int64{12, 13, 17}, leases.retryableReleases)
+	require.Equal(t, []int64{14, 15, 16}, leases.ambiguousReleases)
 }
 
 func TestHandlePollResponseTracksLedgerMetrics(t *testing.T) {

--- a/cmd/tx-load-test/benchmark/sac_transfer.go
+++ b/cmd/tx-load-test/benchmark/sac_transfer.go
@@ -14,9 +14,47 @@ import (
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
 )
 
-// benchmarkBaseFee is the inclusion fee per operation (in stroops) applied to
-// every benchmark transaction, on top of the Soroban resource fee.
-const benchmarkBaseFee int64 = 200
+// benchmarkBaseFeeMin and benchmarkBaseFeeMax bound the per-op inclusion fee
+// (in stroops) randomly chosen for each submitted benchmark transaction.
+//
+// Two reasons we sample per-tx instead of using a single fixed value:
+//
+//  1. Stellar core's SurgePricingUtils::computeBetterFee requires a STRICTLY
+//     greater per-op fee for a new tx to evict (or beat in per-ledger
+//     inclusion ranking) one already in the queue. With identical bids,
+//     every tx after the first ties and is rejected with txINSUFFICIENT_FEE
+//     — observed at 17,666 of 18,000 OZ-transfer submits in a 5-min bench.
+//     Per-tx random sampling makes ties statistically vanishing (collision
+//     rate ~= queue_depth^2 / (2*range_size); 90,001 distinct buckets here).
+//     This is the same primitive stellar-core's own LoadGenerator
+//     (TxGenerator::generateFee) uses.
+//
+//  2. To stay above network surge floors. The [10_000, 100_000] range is
+//     a heuristic starting point: well above the 100-stroop network
+//     minimum and historical futurenet external-surge p95s in the
+//     low-thousands. It is NOT guaranteed to clear self-induced surge on
+//     resource-heavy workloads — at high RPS for OZ/soroswap the bench
+//     can saturate ledger Soroban capacity, the surge floor rises tx-by-
+//     tx, and the upper bound here can be exceeded. Cost on test networks
+//     is negligible: a 100k-stroop inclusion bid is ~0.01 XLM per tx,
+//     and the fee_payer holds free XLM. For pubnet, or for sustained
+//     high-RPS Soroban-heavy benches, the operator should re-tune these
+//     constants based on observed getFeeStats.SorobanInclusionFee.
+const (
+	benchmarkBaseFeeMin int64 = 10_000
+	benchmarkBaseFeeMax int64 = 100_000
+)
+
+// sampleBenchmarkBaseFee returns a per-op inclusion fee uniformly sampled from
+// [benchmarkBaseFeeMin, benchmarkBaseFeeMax]. Call once per submitted tx so
+// each carries a distinct per-op bid; this is what allows successive
+// submissions to avoid the SurgePricingUtils::computeBetterFee tie rule and
+// either be admitted directly (queue not full) or evict a strictly cheaper
+// occupant.
+func sampleBenchmarkBaseFee() int64 {
+	span := benchmarkBaseFeeMax - benchmarkBaseFeeMin + 1
+	return benchmarkBaseFeeMin + rand.Int64N(span)
+}
 
 // sacTransferAmount is 1.0 units of the asset in its 7-decimal raw form.
 const sacTransferAmount = int64(10_000_000)

--- a/cmd/tx-load-test/benchmark/simple_payment.go
+++ b/cmd/tx-load-test/benchmark/simple_payment.go
@@ -63,7 +63,7 @@ func newSimplePaymentTargeter(ctx context.Context, rpcURL string, st *state.Stat
 			},
 			IncrementSequenceNum: false,
 			Operations:           ops,
-			BaseFee:              benchmarkBaseFee,
+			BaseFee:              sampleBenchmarkBaseFee(),
 			Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(benchmarkTransactionTimeoutSecs)},
 		})
 		if err != nil {

--- a/cmd/tx-load-test/benchmark/simulation_helpers.go
+++ b/cmd/tx-load-test/benchmark/simulation_helpers.go
@@ -26,7 +26,7 @@ func presimulateBenchmarkInvocation(
 		txSourceKP,
 		opSourceAddress,
 		invokeArgs,
-		benchmarkBaseFee,
+		benchmarkBaseFeeMin,
 		resourcePadFactor,
 	)
 	if err != nil {

--- a/cmd/tx-load-test/benchmark/tx_builder.go
+++ b/cmd/tx-load-test/benchmark/tx_builder.go
@@ -54,7 +54,7 @@ func buildSorobanSendTransactionBody(params sorobanSendTransactionParams) ([]byt
 		SourceAccount:        &txnbuild.SimpleAccount{AccountID: params.TxSource.Address(), Sequence: params.Sequence},
 		IncrementSequenceNum: false,
 		Operations:           []txnbuild.Operation{&op},
-		BaseFee:              benchmarkBaseFee,
+		BaseFee:              sampleBenchmarkBaseFee(),
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(benchmarkTransactionTimeoutSecs)},
 	})
 	if err != nil {

--- a/cmd/tx-load-test/benchmark/tx_builder_test.go
+++ b/cmd/tx-load-test/benchmark/tx_builder_test.go
@@ -65,13 +65,21 @@ func TestBuildSorobanSendTransactionBodyBuildsSignedJSONRPCRequest(t *testing.T)
 	feeBump, ok := gtx.FeeBump()
 	require.True(t, ok)
 	require.Equal(t, feePayer.Address(), feeBump.FeeAccount())
-	require.Equal(t, benchmarkBaseFee*2+int64(resourceFee), feeBump.MaxFee())
+	// BaseFee is randomly sampled from [benchmarkBaseFeeMin, benchmarkBaseFeeMax]
+	// per submission, so assert against the range rather than a fixed value.
+	require.GreaterOrEqual(t, feeBump.MaxFee(), benchmarkBaseFeeMin*2+int64(resourceFee))
+	require.LessOrEqual(t, feeBump.MaxFee(), benchmarkBaseFeeMax*2+int64(resourceFee))
 	require.Len(t, feeBump.Signatures(), 1)
 
 	tx := feeBump.InnerTransaction()
 	require.Equal(t, txSource.Address(), tx.SourceAccount().AccountID)
 	require.Equal(t, int64(41), tx.SequenceNumber())
-	require.Equal(t, benchmarkBaseFee+int64(resourceFee), tx.BaseFee())
+	require.GreaterOrEqual(t, tx.BaseFee(), benchmarkBaseFeeMin+int64(resourceFee))
+	require.LessOrEqual(t, tx.BaseFee(), benchmarkBaseFeeMax+int64(resourceFee))
+	// feeBump.MaxFee covers (innerOps+1) ops at the inner per-op rate plus the
+	// resource fee once: feeBump.MaxFee == 2*tx.BaseFee - resourceFee, since
+	// txnbuild reports tx.BaseFee as (per-op inclusion fee + resource fee).
+	require.Equal(t, feeBump.MaxFee(), tx.BaseFee()*2-int64(resourceFee))
 	require.Len(t, tx.Signatures(), 2)
 	operations := tx.Operations()
 	require.Len(t, operations, 1)

--- a/cmd/tx-load-test/ledger/ledger.go
+++ b/cmd/tx-load-test/ledger/ledger.go
@@ -230,22 +230,76 @@ func HasPositiveI128(balance xdr.Int128Parts) bool {
 	return balance.Hi > 0 || (balance.Hi == 0 && balance.Lo > 0)
 }
 
-func DecodeTransactionResultCode(resultXDR string) string {
-	if resultXDR == "" {
-		return "unknown"
-	}
+// DecodeTxResult parses a base64-encoded TransactionResult XDR. Callers that
+// need multiple pieces of information from the same XDR (e.g. the formatted
+// code string AND a bad_seq classification) should use this and pass the
+// parsed value into ResultCodeFromTxResult / IsBadSeqFromTxResult to avoid
+// decoding the XDR multiple times in the hot ERROR path.
+func DecodeTxResult(resultXDR string) (xdr.TransactionResult, bool) {
 	var result xdr.TransactionResult
+	if resultXDR == "" {
+		return result, false
+	}
 	if err := xdr.SafeUnmarshalBase64(resultXDR, &result); err != nil {
-		return "decode-error"
+		return result, false
+	}
+	return result, true
+}
+
+// ResultCodeFromTxResult formats a parsed TransactionResult's outer code,
+// descending into the inner code when the outer is TxFeeBumpInnerFailed.
+func ResultCodeFromTxResult(result *xdr.TransactionResult) string {
+	if result == nil {
+		return "unknown"
 	}
 	outer := result.Result.Code.String()
 	if result.Result.Code == xdr.TransactionResultCodeTxFeeBumpInnerFailed {
 		if inner, ok := result.Result.GetInnerResultPair(); ok {
-			innerCode := inner.Result.Result.Code.String()
-			return outer + " (inner: " + innerCode + ")"
+			return outer + " (inner: " + inner.Result.Result.Code.String() + ")"
 		}
 	}
 	return outer
+}
+
+// IsBadSeqFromTxResult reports whether the parsed result encodes a TxBadSeq
+// outcome, either directly or wrapped in TxFeeBumpInnerFailed.
+func IsBadSeqFromTxResult(result *xdr.TransactionResult) bool {
+	if result == nil {
+		return false
+	}
+	if result.Result.Code == xdr.TransactionResultCodeTxBadSeq {
+		return true
+	}
+	if result.Result.Code == xdr.TransactionResultCodeTxFeeBumpInnerFailed {
+		if inner, ok := result.Result.GetInnerResultPair(); ok {
+			return inner.Result.Result.Code == xdr.TransactionResultCodeTxBadSeq
+		}
+	}
+	return false
+}
+
+// DecodeTransactionResultCode is a string-in / string-out wrapper that decodes
+// the XDR and formats the result code in one call. Use this for one-off
+// callsites; in hot loops, prefer DecodeTxResult + ResultCodeFromTxResult.
+func DecodeTransactionResultCode(resultXDR string) string {
+	if resultXDR == "" {
+		return "unknown"
+	}
+	result, ok := DecodeTxResult(resultXDR)
+	if !ok {
+		return "decode-error"
+	}
+	return ResultCodeFromTxResult(&result)
+}
+
+// IsBadSeqResult is a string-in wrapper for IsBadSeqFromTxResult. Prefer the
+// parsed-result variant in hot loops.
+func IsBadSeqResult(resultXDR string) bool {
+	result, ok := DecodeTxResult(resultXDR)
+	if !ok {
+		return false
+	}
+	return IsBadSeqFromTxResult(&result)
 }
 
 func min(a, b int) int {

--- a/cmd/tx-load-test/ledger/ledger_test.go
+++ b/cmd/tx-load-test/ledger/ledger_test.go
@@ -1,0 +1,107 @@
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/require"
+)
+
+// txResultB64 builds a TransactionResult with the given outer code (and
+// optionally a fee-bump inner code) and returns its base64 XDR encoding.
+//
+// The TransactionResult union has variants that carry payloads: TxSuccess /
+// TxFailed (operation results), TxFeeBumpInnerSuccess / TxFeeBumpInnerFailed
+// (an inner-result pair). The InnerTransactionResultResult union has the same
+// pattern for TxSuccess / TxFailed. This helper sets up empty payload slices
+// for those cases so xdr.Marshal does not panic on a missing union member.
+func txResultB64(t *testing.T, outer xdr.TransactionResultCode, inner *xdr.TransactionResultCode) string {
+	t.Helper()
+	r := xdr.TransactionResult{}
+	switch outer {
+	case xdr.TransactionResultCodeTxSuccess, xdr.TransactionResultCodeTxFailed:
+		require.Nil(t, inner, "non-fee-bump outer code does not carry an inner")
+		empty := []xdr.OperationResult{}
+		r.Result = xdr.TransactionResultResult{Code: outer, Results: &empty}
+	case xdr.TransactionResultCodeTxFeeBumpInnerSuccess, xdr.TransactionResultCodeTxFeeBumpInnerFailed:
+		require.NotNil(t, inner, "fee-bump-wrapped result requires an inner code")
+		innerRR := xdr.InnerTransactionResultResult{Code: *inner}
+		switch *inner {
+		case xdr.TransactionResultCodeTxSuccess, xdr.TransactionResultCodeTxFailed:
+			empty := []xdr.OperationResult{}
+			innerRR.Results = &empty
+		}
+		pair := xdr.InnerTransactionResultPair{
+			Result: xdr.InnerTransactionResult{Result: innerRR},
+		}
+		r.Result = xdr.TransactionResultResult{Code: outer, InnerResultPair: &pair}
+	default:
+		require.Nil(t, inner, "non-fee-bump outer code does not carry an inner")
+		r.Result = xdr.TransactionResultResult{Code: outer}
+	}
+	b64, err := xdr.MarshalBase64(r)
+	require.NoError(t, err)
+	return b64
+}
+
+func TestIsBadSeqResult_DirectBadSeq(t *testing.T) {
+	xdrStr := txResultB64(t, xdr.TransactionResultCodeTxBadSeq, nil)
+	require.True(t, IsBadSeqResult(xdrStr))
+}
+
+func TestIsBadSeqResult_FeeBumpWrappedBadSeq(t *testing.T) {
+	inner := xdr.TransactionResultCodeTxBadSeq
+	xdrStr := txResultB64(t, xdr.TransactionResultCodeTxFeeBumpInnerFailed, &inner)
+	require.True(t, IsBadSeqResult(xdrStr))
+}
+
+func TestIsBadSeqResult_FeeBumpWrappedNotBadSeq(t *testing.T) {
+	// fee-bump inner failed for a different reason — must NOT be classified
+	// as bad_seq because routing it to ambiguous would over-trigger recovery.
+	inner := xdr.TransactionResultCodeTxFailed
+	xdrStr := txResultB64(t, xdr.TransactionResultCodeTxFeeBumpInnerFailed, &inner)
+	require.False(t, IsBadSeqResult(xdrStr))
+}
+
+func TestIsBadSeqResult_OtherTopLevelCodes(t *testing.T) {
+	cases := []xdr.TransactionResultCode{
+		xdr.TransactionResultCodeTxSuccess,
+		xdr.TransactionResultCodeTxFailed,
+		xdr.TransactionResultCodeTxInsufficientFee,
+		xdr.TransactionResultCodeTxTooLate,
+		xdr.TransactionResultCodeTxNoAccount,
+	}
+	for _, code := range cases {
+		t.Run(code.String(), func(t *testing.T) {
+			require.False(t, IsBadSeqResult(txResultB64(t, code, nil)))
+		})
+	}
+}
+
+func TestIsBadSeqResult_EmptyAndInvalid(t *testing.T) {
+	require.False(t, IsBadSeqResult(""), "empty XDR is not bad_seq")
+	require.False(t, IsBadSeqResult("not-base64"), "invalid base64 is not bad_seq")
+	require.False(t, IsBadSeqResult("AAAA"), "truncated XDR is not bad_seq")
+}
+
+func TestIsBadSeqFromTxResult_NilSafety(t *testing.T) {
+	require.False(t, IsBadSeqFromTxResult(nil))
+}
+
+func TestDecodeTransactionResultCode_FormatsBoth(t *testing.T) {
+	// Plain bad_seq.
+	require.Equal(t,
+		xdr.TransactionResultCodeTxBadSeq.String(),
+		DecodeTransactionResultCode(txResultB64(t, xdr.TransactionResultCodeTxBadSeq, nil)),
+	)
+	// Fee-bump-wrapped bad_seq formats as "outer (inner: TxBadSeq)".
+	inner := xdr.TransactionResultCodeTxBadSeq
+	got := DecodeTransactionResultCode(txResultB64(t, xdr.TransactionResultCodeTxFeeBumpInnerFailed, &inner))
+	require.Contains(t, got, xdr.TransactionResultCodeTxFeeBumpInnerFailed.String())
+	require.Contains(t, got, "inner: "+xdr.TransactionResultCodeTxBadSeq.String())
+}
+
+func TestDecodeTransactionResultCode_EmptyAndInvalid(t *testing.T) {
+	require.Equal(t, "unknown", DecodeTransactionResultCode(""))
+	require.Equal(t, "decode-error", DecodeTransactionResultCode("not-base64"))
+}

--- a/cmd/tx-load-test/state/tx_results.go
+++ b/cmd/tx-load-test/state/tx_results.go
@@ -36,17 +36,27 @@ func logTxFailure(logger *log.Entry, hash, resultXDR string, diagnosticEventsXDR
 
 // DecodeOperationResults extracts per-operation result summaries from a base64
 // TransactionResult XDR string, descending into fee-bump inner results when
-// the outer code is TxFeeBumpInnerFailed. Returns nil if there are no
-// operation-level results to report (e.g. pre-apply rejections).
+// the outer code is TxFeeBumpInnerSuccess or TxFeeBumpInnerFailed. Returns
+// nil if there are no operation-level results to report (e.g. pre-apply
+// rejections, or unwrapped fee-bump outer codes).
+//
+// Use this for one-off callsites; in hot loops where the same XDR is also
+// passed to other decoders, prefer ledger.DecodeTxResult +
+// OperationResultsFromTxResult so the XDR is decoded once.
 func DecodeOperationResults(resultXDR string) []string {
-	if resultXDR == "" {
+	result, ok := ledger.DecodeTxResult(resultXDR)
+	if !ok {
 		return nil
 	}
-	var result xdr.TransactionResult
-	if err := xdr.SafeUnmarshalBase64(resultXDR, &result); err != nil {
-		return nil
-	}
+	return OperationResultsFromTxResult(&result)
+}
 
+// OperationResultsFromTxResult is the parsed-result variant of
+// DecodeOperationResults.
+func OperationResultsFromTxResult(result *xdr.TransactionResult) []string {
+	if result == nil {
+		return nil
+	}
 	var opResults []xdr.OperationResult
 	switch result.Result.Code {
 	case xdr.TransactionResultCodeTxSuccess, xdr.TransactionResultCodeTxFailed:


### PR DESCRIPTION
### What

Robustness fixes to the `tx-load-test` benchmarker. Two independent changes:

1. **Sample per-tx base fee from a `[10_000, 100_000]` stroops/op range.** Replaces the single `benchmarkBaseFee` constant. Each submitted tx draws a fresh per-op inclusion fee uniformly from the range. Same primitive stellar-core's `LoadGenerator` (`simulation/TxGenerator::generateFee`) uses.

2. **Route `bad_seq` submit errors to chain-state recovery.** When `sendTransaction` returns `txERROR` with a `tx_bad_seq` (or `tx_fee_bump_inner_failed → tx_bad_seq`), call `ReleaseAmbiguous` instead of `ReleaseRetryable`. New `ledger.IsBadSeqFromTxResult` and a small refactor decode the error XDR once and feed the parsed result into all the helpers that need it. Adds `ledger_test.go` covering the bad_seq classifier with synthesized XDR fixtures.

### Why

#### Per-tx fee jitter

Stellar core's `SurgePricingUtils::computeBetterFee` (`SurgePricingUtils.cpp:68`, `minFee = v + 1`) requires a *strictly greater* per-op fee for a new tx to evict (or beat in per-ledger ranking) one already in the soroban / classic queue. Identical bids tie, and ties lose. With every submission carrying the same fee, all but the first tie and are rejected with `txINSUFFICIENT_FEE`.

Empirical confirmation in this branch: at SAC 200 RPS (saturating the queue), a constant 1,000-stroop bid produced **58.7% `txINSUFFICIENT_FEE` rejection** (3,223 / 5,490 submits); a `[500, 1500]` jittered bid at the same mean produced **24.1% rejection** (1,323 / 5,486). Same load, same mean — only the per-tx variance differs.

The `[10_000, 100_000]` range is a heuristic starting point: well above the 100-stroop network minimum and above historical futurenet external-surge `SorobanInclusionFee.p95` values in the low thousands. It is **not** guaranteed to clear self-induced surge on resource-heavy workloads (e.g. OZ-transfer, soroswap) at sustained high RPS — at over-capacity load the surge floor rises tx-by-tx and can exceed even the upper bound. The doc comment in `sac_transfer.go` calls this out and recommends operators re-tune from observed `getFeeStats.SorobanInclusionFee` for pubnet or sustained Soroban-heavy workloads.

Cost is negligible on test networks: a 100k-stroop inclusion bid is ~0.01 XLM per tx, and the fee_payer holds free XLM.

#### `bad_seq` → recovery

`ReleaseRetryable` rolls cached seq back to `assignedSeq − 1` so the next Acquire reuses the same seq. For most ERROR codes that's correct: chain seq is unchanged. For `tx_bad_seq` it's wrong — `bad_seq` *means* our cached seq is out of sync with chain. Rolling back and retrying reproduces the same error indefinitely. Routing through `ReleaseAmbiguous` triggers the existing recovery path (`LoadAccount`) so the next attempt uses the live chain seq.

### Known limitations

- The `[10_000, 100_000]` defaults are tuned for test-network use. For pubnet stress testing, or for sustained high-RPS Soroban-heavy workloads, the operator should re-tune from `getFeeStats` observations.
- The bad_seq routing relies on captive-core surfacing `tx_bad_seq` (or `tx_fee_bump_inner_failed` with inner `tx_bad_seq`) in `errorResultXdr`. Other XDR-encoded error codes still go through the rollback path, which remains correct for them.
- All changes are additive and minimal. None alter user-facing CLI flags, state-file format, or metrics output.
