### PR TITLE
Restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # stellar-rpc-blaster
-CLI load testing tool for Stellar RPC
+CLI load-testing tools for Stellar RPC.
 
-This repo is home to our RPC load testing tool. It has the ability to test various endpoints on one's RPC server. 
+This repo contains two tools:
+
+- `stellar-rpc-blaster` -- configurable RPC request load generation from sampled ledger data.
+- `tx-load-test` -- standalone transaction load testing for SAC transfers, OZ token transfers, Soroswap swaps, and a parallel classic-payment stream. See [cmd/tx-load-test/README.md](cmd/tx-load-test/README.md) for setup, benchmark, teardown, and metrics-output details.
+
+## Build
+
+```bash
+go build -o stellar-rpc-blaster .
+go build -o tx-load-test ./cmd/tx-load-test/
+```
 
 ### Running
 

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -65,11 +65,13 @@ Creates all required ledger state and writes `state.json`. If a state file alrea
 | `--soroswap-router` | *(required on `testnet`/`mainnet`)* | Soroswap router contract ID; optional on `standalone`/`futurenet`, where setup can auto-deploy it |
 | `--liquidity-per-pool` | `1000000` | Token units of each asset to seed into each Soroswap benchmark pool |
 | `--accounts` | `5000` | Target number of participant accounts |
-| `--base-reserve-xlm` | `3.0` | XLM to fund each account |
+| `--base-reserve-xlm` | `3.0` | XLM to fund each account; covers the three-trustline holder reserve plus fee/headroom |
 | `--state-file` | `state.json` | Output state file path |
 | `--log-level` | `info` | `debug`, `info`, `warn`, `error` |
 
 The fee-payer seed is read from the `FEE_PAYER` environment variable. If unset, a temporary keypair is generated and funded via friendbot (testnet/futurenet only).
+
+The `--base-reserve-xlm` default is intentionally conservative. On current public networks the Stellar base reserve is 0.5 XLM, and a benchmark holder account needs three classic asset trustlines (`BLTA`, `BLTB`, `BLTC`). Stellar minimum balance is `(2 + subentry count) * base reserve`, so a holder requires `(2 account reserves + 3 trustline reserves) * 0.5 = 2.5 XLM`. Funding each account with 3.0 XLM leaves about 0.5 XLM per holder for small incidental fees, append/repair operations, and reserve-parameter headroom. Passive accounts do not need the trustline reserves, but setup uses one funding amount for all participant accounts so every account can be promoted to the holder subset later.
 
 If `setup` is re-run against an existing `state.json`, `FEE_PAYER` must be set and must match the hash recorded in the state file.
 Re-running `setup` requires the resolved network passphrase to match the value already recorded in `state.json`. The `--rpc-url` may change, but the chosen endpoint must report that same passphrase via `getNetwork`.

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -110,7 +110,7 @@ If setup is interrupted, a best-effort cleanup merges whatever accounts exist an
 
 Restores archived Soroban state before a benchmark run. This command is meant for state files that sit idle between infrequent tests, especially `oz-transfer` and `soroswap`, where account-specific contract data can archive.
 
-`restore` uses simulation only inside this maintenance command. It does not submit the benchmark transfer/swap invokes used as probes; it submits only `RestoreFootprint` transactions when simulation reports archived state. The hot benchmark path remains simulation-free per generated request.
+`restore` uses simulation only inside this maintenance command. It does not submit the benchmark transfer/swap invokes used as probes; it submits only `RestoreFootprint` transactions when simulation reports archived state. For `soroswap`, the command also runs a secondary benchmark-footprint validation pass: it builds the same rewritten footprints used by the benchmark targeter, compares them with fresh simulation footprints, and fails on missing or unexpected contract-data keys. The hot benchmark path remains simulation-free per generated request.
 
 | Flag | Default | Description |
 |---|---|---|
@@ -142,12 +142,12 @@ export FEE_PAYER="S..."
 ./tx-load-test restore --mode oz-transfer --account-start 500 --account-limit 500 --verify
 ```
 
-Each mode logs a start message, an update after the first probe, periodic progress every `--progress-interval` probes, a final progress update, and a summary. Progress and summary logs include probes simulated, restore-needed probes, restore transactions submitted, no-op probes, restored read-only/read-write key counts, selected account range, selected account count, elapsed time, and the first few errors. In `--dry-run`, summaries use “would restore” wording and `restoreTransactions=0`.
+Each mode logs a start message, an update after the first probe, periodic progress every `--progress-interval` probes, a final progress update, and a summary. Progress and summary logs include probes simulated, restore-needed probes, restore transactions submitted, no-op probes, restored read-only/read-write key counts, selected account range, selected account count, elapsed time, and the first few errors. In `--dry-run`, summaries use “would restore” wording and `restoreTransactions=0`. Soroswap additionally logs `soroswap benchmark footprint validation summary` with template/probe counts, restore-needed validation probes, footprint mismatches, missing keys, unexpected keys, and allowed extra read-write trustline keys.
 
-`--account-limit` limits selected accounts, not total probe count. `oz-transfer` runs one restore probe per selected account. `soroswap` runs four probes per selected holder account because it checks two benchmark pools in both swap directions. With `--mode all --account-limit 1000`, the command can therefore run up to 3 SAC probes, 1000 OZ probes, and 4000 Soroswap probes.
+`--account-limit` limits selected accounts, not total probe count. `sac-transfer` runs one representative transfer probe per selected holder account per SAC contract. `oz-transfer` runs one restore probe per selected account. `soroswap` runs four probes per selected holder account because it checks two benchmark pools in both swap directions. With `--mode all --account-limit 1000`, the command can therefore run up to 3000 SAC probes, 1000 OZ probes, and 4000 Soroswap probes.
 
 Mode-specific scope:
-- **`sac-transfer`** probes only the three shared SAC contract instances. Participant balances are classic trustlines and are not Soroban archived state.
+- **`sac-transfer`** runs representative transfer probes from each selected holder account against the three SAC contracts so simulation can restore both SAC WASM/code and contract instance state, plus any account-specific SAC contract data a transfer simulation reports. Participant balances are classic trustlines and are not Soroban archived state.
 - **`oz-transfer`** probes selected participant accounts so each selected account's OZ `Balance` contract data is touched at least once.
 - **`soroswap`** probes selected holder accounts across the benchmark pools and both swap directions, covering shared router/pair/pool state and account-specific trader contract data.
 

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -7,11 +7,12 @@ A standalone Stellar Soroban RPC load-testing tool. It drives sustained transact
 The tool is split into three independent phases connected by a JSON state file:
 
 ```
-setup  -->  state.json  -->  bench  (repeatable)
+setup  -->  state.json  -->  restore  -->  bench  (repeatable)
                         -->  teardown
 ```
 
 - **`setup`** -- one-time ledger initialization: creates accounts, assets, trustlines, SAC contracts, Soroswap pools/liquidity, and the OZ benchmark token. Re-running with a higher `--accounts` value adds accounts incrementally.
+- **`restore`** -- optional pre-benchmark maintenance: simulates benchmark-shaped probes, restores archived Soroban state, and logs per-mode restore summaries without running benchmark traffic.
 - **`bench`** -- drives load against the RPC endpoint using pre-built state. Run as many times as needed.
 - **`teardown`** -- merges all participant accounts back into the fee payer, recovering XLM. Deletes the state file on success.
 - **`sync`** -- reconciles the state file with on-chain reality (removes accounts that no longer exist).
@@ -36,15 +37,21 @@ go build -o tx-load-test ./cmd/tx-load-test/
 export FEE_PAYER="S..."  # optional; omit to auto-generate via friendbot
 ./tx-load-test setup --rpc-url https://soroban-testnet.stellar.org --network testnet --accounts 3000
 
-# 2. Run a benchmark (requires the same fee-payer seed used for setup)
+# 2. If the state has been idle, dry-run restore first (requires the same fee-payer seed used for setup)
 export FEE_PAYER="S..."
+./tx-load-test restore --mode all --dry-run
+
+# 3. Restore archived state if the dry-run reports restore-needed probes
+./tx-load-test restore --mode all --verify
+
+# 4. Run a benchmark
 ./tx-load-test bench --mode sac-transfer --target-rps 300 --duration 60s
 # Writes flattened metrics to tx-load-test-metrics-<timestamp>-sac-transfer.ndjson by default.
 
-# 3. Need more accounts? Just re-run setup with a higher target.
+# 5. Need more accounts? Just re-run setup with a higher target.
 ./tx-load-test setup --rpc-url https://soroban-testnet.stellar.org --network testnet --accounts 5000
 
-# 4. Clean up (also requires FEE_PAYER)
+# 6. Clean up (also requires FEE_PAYER)
 ./tx-load-test teardown
 ```
 
@@ -98,6 +105,51 @@ If setup is interrupted, a best-effort cleanup merges whatever accounts exist an
 # Later, expand to 5000 -- only accounts 2001-5000 are created
 ./tx-load-test setup --rpc-url https://... --network testnet --accounts 5000
 ```
+
+### `restore`
+
+Restores archived Soroban state before a benchmark run. This command is meant for state files that sit idle between infrequent tests, especially `oz-transfer` and `soroswap`, where account-specific contract data can archive.
+
+`restore` uses simulation only inside this maintenance command. It does not submit the benchmark transfer/swap invokes used as probes; it submits only `RestoreFootprint` transactions when simulation reports archived state. The hot benchmark path remains simulation-free per generated request.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--mode` | `all` | Restore scope: `all`, `sac-transfer`, `oz-transfer`, or `soroswap` |
+| `--dry-run` | `false` | Simulate and log what would need restore; submit no restore transactions |
+| `--verify` | `false` | After restore, re-run the selected probes and fail if any still require restore |
+| `--account-start` | `0` | 0-based offset into the selected participant account list |
+| `--account-limit` | `0` | Maximum selected accounts per applicable mode; `0` means all remaining accounts |
+| `--progress-interval` | `100` | Log restore progress every N probes; set negative to disable periodic progress |
+| `--rpc-url` | *(from state file)* | Override the RPC URL stored in `state.json` |
+| `--state-file` | `state.json` | Input state file path |
+| `--skip-account-preflight` | `false` | Skip the sampled on-chain participant-account existence check before restore starts |
+| `--account-preflight-sample` | `10` | Number of participant accounts to sample during runtime preflight |
+| `--log-level` | `info` | `debug`, `info`, `warn`, `error` |
+
+Example workflow:
+
+```bash
+export FEE_PAYER="S..."
+
+# See how much archived state would need restoring.
+./tx-load-test restore --mode all --dry-run
+
+# Restore and verify the selected probes are live afterwards.
+./tx-load-test restore --mode all --verify
+
+# For large states, restore in chunks.
+./tx-load-test restore --mode oz-transfer --account-start 0 --account-limit 500 --verify
+./tx-load-test restore --mode oz-transfer --account-start 500 --account-limit 500 --verify
+```
+
+Each mode logs a start message, an update after the first probe, periodic progress every `--progress-interval` probes, a final progress update, and a summary. Progress and summary logs include probes simulated, restore-needed probes, restore transactions submitted, no-op probes, restored read-only/read-write key counts, selected account range, selected account count, elapsed time, and the first few errors. In `--dry-run`, summaries use “would restore” wording and `restoreTransactions=0`.
+
+`--account-limit` limits selected accounts, not total probe count. `oz-transfer` runs one restore probe per selected account. `soroswap` runs four probes per selected holder account because it checks two benchmark pools in both swap directions. With `--mode all --account-limit 1000`, the command can therefore run up to 3 SAC probes, 1000 OZ probes, and 4000 Soroswap probes.
+
+Mode-specific scope:
+- **`sac-transfer`** probes only the three shared SAC contract instances. Participant balances are classic trustlines and are not Soroban archived state.
+- **`oz-transfer`** probes selected participant accounts so each selected account's OZ `Balance` contract data is touched at least once.
+- **`soroswap`** probes selected holder accounts across the benchmark pools and both swap directions, covering shared router/pair/pool state and account-specific trader contract data.
 
 ### `bench`
 

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -46,7 +46,7 @@ export FEE_PAYER="S..."
 
 # 4. Run a benchmark
 ./tx-load-test bench --mode sac-transfer --target-rps 300 --duration 60s
-# Writes flattened metrics to tx-load-test-metrics-<timestamp>-sac-transfer.ndjson by default.
+# Writes flattened metrics to metrics/tx-load-test-metrics-<timestamp>-sac-transfer.ndjson by default.
 
 # 5. Need more accounts? Just re-run setup with a higher target.
 ./tx-load-test setup --rpc-url https://soroban-testnet.stellar.org --network testnet --accounts 5000
@@ -170,7 +170,7 @@ Before the benchmark starts, the tool queries the chosen RPC endpoint (either `-
 | `--skip-account-preflight` | `false` | Skip the sampled on-chain participant-account existence check before the benchmark starts |
 | `--account-preflight-sample` | `10` | Number of participant accounts to sample during runtime preflight |
 | `--trace-file` | *(disabled)* | Optional NDJSON file that captures every benchmark submit and poll request/response |
-| `--metrics-file` | `tx-load-test-metrics-<timestamp>-<mode>.ndjson` | Optional flattened NDJSON benchmark metrics file path |
+| `--metrics-file` | `metrics/tx-load-test-metrics-<timestamp>-<mode>.ndjson` | Optional flattened benchmark metrics file path |
 | `--log-level` | `info` | `debug`, `info`, `warn`, `error` |
 
 **Mode guide:**
@@ -206,7 +206,7 @@ When `--classic-rps > 0`, bench also runs a parallel simple-payment companion st
 
 When `--trace-file` is enabled, bench also writes every submit and poll request/response pair to the specified NDJSON file for post-run analysis.
 
-**Metrics file output:** bench writes a flattened NDJSON metrics file. If `--metrics-file` is omitted, the default path is `tx-load-test-metrics-<timestamp>-<mode>.ndjson`.
+**Metrics file output:** bench writes a flattened NDJSON metrics file. If `--metrics-file` is omitted, the default path is `metrics/tx-load-test-metrics-<timestamp>-<mode>.ndjson`.
 
 The metrics file is newline-delimited JSON. Each workload produces one `summary` record that combines run parameters, workload parameters, submission counters, on-chain counters, latency stats, ledger stats, Vegeta metrics, and HTTP status-code counts. HTTP status codes are flattened into fields on the summary record, for example `vegeta_status_code_200`, not emitted as separate records.
 

--- a/cmd/tx-load-test/bench_cmd.go
+++ b/cmd/tx-load-test/bench_cmd.go
@@ -32,9 +32,9 @@ transaction, and --classic-rps is interpreted as transactions/sec.
 Use --trace-file to capture every benchmark submit and poll request/response
 as NDJSON for post-run inspection.
 
-Benchmark summary metrics are also written as flattened NDJSON. By default the
-metrics filename includes the start timestamp and selected mode; use
---metrics-file to choose a specific path.
+Benchmark summary metrics are also written as flattened NDJSON. By default
+the metrics file is written under metrics/ with a filename that includes the
+start timestamp and selected mode; use --metrics-file to choose a specific path.
 
 bench reads the state file produced by setup and drives benchmark transaction
 traffic against the target network without modifying local setup metadata.
@@ -53,7 +53,7 @@ Run bench as many times as needed.`,
 	cmd.Flags().Int("target-rps", 50, "Steady-state requests per second after ramp-up")
 	cmd.Flags().Int("classic-rps", config.DefaultClassicRPS, "Steady-state simple-payment transactions per second after ramp-up (1 payment op per tx)")
 	cmd.Flags().String("trace-file", "", "Optional newline-delimited JSON file that captures every benchmark submit and poll request/response")
-	cmd.Flags().String("metrics-file", "", "Optional NDJSON file for benchmark metrics (default: timestamped filename containing the selected mode)")
+	cmd.Flags().String("metrics-file", "", "Optional NDJSON file for benchmark metrics (default: metrics/ timestamped filename containing the selected mode)")
 	return cmd
 }
 

--- a/cmd/tx-load-test/benchmark/account_manager.go
+++ b/cmd/tx-load-test/benchmark/account_manager.go
@@ -13,6 +13,14 @@ import (
 
 const accountRecoveryRetryDelay = 2 * time.Second
 
+// accountRecoveryWorkers bounds how many poisoned accounts can be reloading
+// chain truth (LoadAccount) concurrently. A poll timeout poisons an account and
+// queues it for recovery; with a single worker, one slow 30s LoadAccount stalls
+// the whole queue and the available pool collapses (the failure mode that drove
+// the lease-starvation spiral). A modest pool drains recovery in parallel while
+// staying small enough not to pile onto an already-loaded RPC.
+const accountRecoveryWorkers = 32
+
 type accountRequirement uint8
 
 const (
@@ -107,7 +115,13 @@ func newAccountManager(ctx context.Context, st *state.State) (*accountManager, e
 	}
 	manager.generalPreferred = append(manager.generalPreferred, manager.trustlinedEligible...)
 
-	go manager.runRecoveryLoop()
+	recoveryWorkers := min(accountRecoveryWorkers, len(manager.accounts))
+	if recoveryWorkers < 1 {
+		recoveryWorkers = 1
+	}
+	for range recoveryWorkers {
+		go manager.runRecoveryLoop()
+	}
 
 	return manager, nil
 }

--- a/cmd/tx-load-test/benchmark/benchmark_test.go
+++ b/cmd/tx-load-test/benchmark/benchmark_test.go
@@ -92,7 +92,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeSACTransfer,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 500,
+				NumberOfAccounts: 750,
 			},
 			wantErr: false,
 		},
@@ -102,7 +102,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeOZTransfer,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 500,
+				NumberOfAccounts: 750,
 			},
 			wantErr: false,
 		},
@@ -112,7 +112,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeSoroswap,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 500,
+				NumberOfAccounts: 750,
 			},
 			wantErr: false,
 		},
@@ -122,7 +122,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.BenchmarkMode("unknown-mode"),
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 500,
+				NumberOfAccounts: 750,
 			},
 			wantErr: true,
 		},
@@ -132,7 +132,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeSACTransfer,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 499,
+				NumberOfAccounts: 749,
 			},
 			wantErr: true,
 		},
@@ -142,7 +142,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeSACTransfer,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 499,
+				NumberOfAccounts: 749,
 			},
 			wantErr: true,
 		},
@@ -152,7 +152,7 @@ func TestValidateConfig(t *testing.T) {
 				Mode:             config.ModeSACTransfer,
 				TargetRPS:        50,
 				ClassicRPS:       0,
-				NumberOfAccounts: 500,
+				NumberOfAccounts: 750,
 			},
 			wantErr: false,
 		},
@@ -183,7 +183,7 @@ func TestValidateConfig(t *testing.T) {
 				TargetRPS:        200,
 				ClassicRPS:       200,
 				Duration:         2 * time.Minute,
-				NumberOfAccounts: 3_999,
+				NumberOfAccounts: 5_999,
 			},
 			wantErr: true,
 		},
@@ -194,7 +194,7 @@ func TestValidateConfig(t *testing.T) {
 				TargetRPS:        200,
 				ClassicRPS:       200,
 				Duration:         2 * time.Minute,
-				NumberOfAccounts: 4_000,
+				NumberOfAccounts: 6_000,
 			},
 			wantErr: false,
 		},
@@ -226,7 +226,7 @@ func TestValidateSetupConfig(t *testing.T) {
 			TargetRPS:        200,
 			ClassicRPS:       200,
 			Duration:         2 * time.Minute,
-			NumberOfAccounts: 4_000,
+			NumberOfAccounts: 6_000,
 		})
 		require.NoError(t, err)
 	})
@@ -236,9 +236,9 @@ func TestValidateSetupConfig(t *testing.T) {
 			TargetRPS:        200,
 			ClassicRPS:       200,
 			Duration:         2 * time.Minute,
-			NumberOfAccounts: 3_999,
+			NumberOfAccounts: 5_999,
 		})
-		require.EqualError(t, err, "benchmark shape is not valid for mode=sac-transfer: account pool too small for configured benchmark: have 3999 accounts but need at least 4000 for the shared tx-source pool  -- increase --accounts, reduce --target-rps, reduce --classic-rps, or shorten --duration")
+		require.EqualError(t, err, "benchmark shape is not valid for mode=sac-transfer: account pool too small for configured benchmark: have 5999 accounts but need at least 6000 for the shared tx-source pool  -- increase --accounts, reduce --target-rps, reduce --classic-rps, or shorten --duration")
 	})
 }
 

--- a/cmd/tx-load-test/benchmark/diagnostics.go
+++ b/cmd/tx-load-test/benchmark/diagnostics.go
@@ -6,31 +6,65 @@ import (
 	"github.com/stellar/go-stellar-sdk/xdr"
 )
 
+const (
+	maxDiagnosticEventSummaries = 4
+	maxDiagnosticTokensPerEvent = 6
+)
+
+const (
+	diagnosticPriorityError = iota
+	diagnosticPriorityOther
+	diagnosticPriorityCall
+)
+
 func summarizeDiagnosticEvents(events []string) string {
+	var grouped [3][]string
+	seen := make(map[string]struct{}, len(events))
 	for _, encoded := range events {
-		if summary := summarizeDiagnosticEvent(encoded); summary != "" {
-			return summary
+		summary, priority := summarizeDiagnosticEventWithPriority(encoded)
+		if summary == "" {
+			continue
+		}
+		if _, ok := seen[summary]; ok {
+			continue
+		}
+		seen[summary] = struct{}{}
+		grouped[priority] = append(grouped[priority], summary)
+	}
+
+	parts := make([]string, 0, maxDiagnosticEventSummaries)
+	for _, summaries := range grouped {
+		for _, summary := range summaries {
+			parts = append(parts, summary)
+			if len(parts) == maxDiagnosticEventSummaries {
+				return strings.Join(parts, " ; ")
+			}
 		}
 	}
-	return ""
+	return strings.Join(parts, " ; ")
 }
 
 func summarizeDiagnosticEvent(encoded string) string {
+	summary, _ := summarizeDiagnosticEventWithPriority(encoded)
+	return summary
+}
+
+func summarizeDiagnosticEventWithPriority(encoded string) (string, int) {
 	var event xdr.DiagnosticEvent
 	if err := xdr.SafeUnmarshalBase64(encoded, &event); err != nil {
-		return ""
+		return "", diagnosticPriorityOther
 	}
 
 	body, ok := event.Event.Body.GetV0()
 	if !ok {
-		return ""
+		return "", diagnosticPriorityOther
 	}
 	tokens := append(normalizeDiagnosticScVals(body.Topics), normalizeDiagnosticScVal(body.Data)...)
 	if len(tokens) == 0 || isCoreMetricsDiagnostic(tokens) {
-		return ""
+		return "", diagnosticPriorityOther
 	}
 
-	parts := make([]string, 0, 2)
+	parts := make([]string, 0, maxDiagnosticTokensPerEvent)
 	seen := make(map[string]struct{}, len(tokens))
 	for _, token := range tokens {
 		switch token {
@@ -42,14 +76,28 @@ func summarizeDiagnosticEvent(encoded string) string {
 		}
 		seen[token] = struct{}{}
 		parts = append(parts, token)
-		if len(parts) == 2 {
+		if len(parts) == maxDiagnosticTokensPerEvent {
 			break
 		}
 	}
 	if len(parts) == 0 {
-		return ""
+		return "", diagnosticPriorityOther
 	}
-	return strings.Join(parts, " | ")
+	return strings.Join(parts, " | "), diagnosticPriority(tokens)
+}
+
+func diagnosticPriority(tokens []string) int {
+	priority := diagnosticPriorityOther
+	for _, token := range tokens {
+		if token == "fn_call" {
+			priority = diagnosticPriorityCall
+		}
+		lower := strings.ToLower(token)
+		if token == "error" || strings.Contains(lower, "error") || strings.Contains(lower, "failed") {
+			return diagnosticPriorityError
+		}
+	}
+	return priority
 }
 
 func normalizeDiagnosticScVals(values []xdr.ScVal) []string {

--- a/cmd/tx-load-test/benchmark/footprint_test.go
+++ b/cmd/tx-load-test/benchmark/footprint_test.go
@@ -92,13 +92,252 @@ func TestBuildSACFootprintFromTemplateReplacesTrustlineKeys(t *testing.T) {
 		},
 	}
 
-	footprint, err := buildSACFootprintFromTemplate(tmpl, asset, srcID, dstID)
+	footprint, ext, err := buildSACFootprintFromTemplate(tmpl, xdr.SorobanTransactionDataExt{}, asset, srcID, dstID)
 	require.NoError(t, err)
 
 	require.Equal(t, tmpl.ReadOnly, footprint.ReadOnly)
 	require.Len(t, footprint.ReadWrite, 2)
 	require.Equal(t, srcID, footprint.ReadWrite[0].TrustLine.AccountId)
 	require.Equal(t, dstID, footprint.ReadWrite[1].TrustLine.AccountId)
+	require.Equal(t, int32(0), int32(ext.V))
+}
+
+func TestBuildSACFootprintFromTemplatePreservesNonTrustlineReadWriteKeys(t *testing.T) {
+	issuer, err := keypair.Random()
+	require.NoError(t, err)
+	templateSrc, err := keypair.Random()
+	require.NoError(t, err)
+	templateDst, err := keypair.Random()
+	require.NoError(t, err)
+	src, err := keypair.Random()
+	require.NoError(t, err)
+	dst, err := keypair.Random()
+	require.NoError(t, err)
+
+	issuerID := mustAccountID(t, issuer.Address())
+	asset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'U', 'S', 'D'},
+			Issuer:    issuerID,
+		},
+	}
+	contractInstanceKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &xdr.ContractId{42},
+			},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{
+			contractInstanceKey,
+			mustTrustlineKey(t, asset, templateSrc.Address()),
+			mustTrustlineKey(t, asset, templateDst.Address()),
+		},
+	}
+
+	footprint, ext, err := buildSACFootprintFromTemplate(tmpl, xdr.SorobanTransactionDataExt{}, asset, mustAccountID(t, src.Address()), mustAccountID(t, dst.Address()))
+	require.NoError(t, err)
+
+	require.Equal(t, []xdr.LedgerKey{
+		contractInstanceKey,
+		mustTrustlineKey(t, asset, src.Address()),
+		mustTrustlineKey(t, asset, dst.Address()),
+	}, footprint.ReadWrite)
+	require.Equal(t, int32(0), int32(ext.V))
+}
+
+// TestBuildSACFootprintFromTemplateFiltersDespitePointerInequality is a
+// regression for the bug where Go's `==` on AlphaNum4 compares the
+// Issuer.Ed25519 pointer rather than the 32 bytes it points at. The
+// simulator's per-tx XDR responses carry freshly-allocated pointers, so the
+// old struct-equality compare returned false for assets that were logically
+// identical -- the filter never matched and every per-asset trustline from
+// the template survived alongside the appended per-request trustlines,
+// producing core's "duplicate key in the Soroban footprint" rejection.
+func TestBuildSACFootprintFromTemplateFiltersDespitePointerInequality(t *testing.T) {
+	issuer, err := keypair.Random()
+	require.NoError(t, err)
+	templateHolder, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+
+	// Build two AlphaNum4 values that are logically identical but use
+	// distinct Issuer pointer instances -- exactly the shape the bug
+	// produced. Each AddressToAccountId call mallocs a new *Uint256.
+	templateIssuerID, err := xdr.AddressToAccountId(issuer.Address())
+	require.NoError(t, err)
+	runtimeIssuerID, err := xdr.AddressToAccountId(issuer.Address())
+	require.NoError(t, err)
+	templateAsset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'B', 'L', 'T', 'C'},
+			Issuer:    templateIssuerID,
+		},
+	}
+	runtimeAsset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'B', 'L', 'T', 'C'},
+			Issuer:    runtimeIssuerID,
+		},
+	}
+	// Sanity: prove the two AlphaNum4 use distinct Issuer.Ed25519 pointer
+	// instances. Go's `==` walks the embedded AccountId.PublicKey and
+	// compares Ed25519 by pointer address rather than by 32-byte value, so
+	// `*templateAsset.AlphaNum4 == *runtimeAsset.AlphaNum4` was the
+	// originally-broken comparison path. require.NotEqual uses
+	// reflect.DeepEqual (which dereferences) so we assert pointer
+	// inequality directly here.
+	require.NotSame(t, templateAsset.AlphaNum4.Issuer.Ed25519, runtimeAsset.AlphaNum4.Issuer.Ed25519,
+		"test fixture must use distinct *Uint256 instances to exercise the pointer-compare regression")
+
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{
+			mustTrustlineKey(t, templateAsset, templateHolder.Address()),
+		},
+	}
+	footprint, _, err := buildSACFootprintFromTemplate(
+		tmpl,
+		xdr.SorobanTransactionDataExt{},
+		runtimeAsset,
+		mustAccountID(t, actualSrc.Address()),
+		mustAccountID(t, actualDst.Address()),
+	)
+	require.NoError(t, err)
+	require.Len(t, footprint.ReadWrite, 2,
+		"template's BLTC trustline must be filtered out before appending the actual src/dst trustlines")
+	require.Equal(t, mustAccountID(t, actualSrc.Address()), footprint.ReadWrite[0].TrustLine.AccountId)
+	require.Equal(t, mustAccountID(t, actualDst.Address()), footprint.ReadWrite[1].TrustLine.AccountId)
+}
+
+// TestBuildSACFootprintFromTemplateRemapsArchivedSorobanEntries verifies that
+// autorestore indices are translated after the per-asset trustlines are
+// filtered out and the actual src/dst trustlines are appended. Without
+// remapping, the original archived index would either point off the end of
+// the new RW (out-of-bounds at core's submit validation) or at a classic
+// trustline (non-persistent error).
+func TestBuildSACFootprintFromTemplateRemapsArchivedSorobanEntries(t *testing.T) {
+	issuer, err := keypair.Random()
+	require.NoError(t, err)
+	templateHolder0, err := keypair.Random()
+	require.NoError(t, err)
+	templateHolder1, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+
+	asset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'B', 'L', 'T', 'C'},
+			Issuer:    mustAccountID(t, issuer.Address()),
+		},
+	}
+	contractInstanceKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &xdr.ContractId{42},
+			},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	// Simulator output shape when the SAC contract instance is archived:
+	// holder trustlines come first (RW for the transfer) and the instance
+	// entry is appended (RW because it needs auto-restoration). The
+	// archived index points at the instance entry at position 2.
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{
+			mustTrustlineKey(t, asset, templateHolder0.Address()),
+			mustTrustlineKey(t, asset, templateHolder1.Address()),
+			contractInstanceKey,
+		},
+	}
+	tmplExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{2},
+		},
+	}
+
+	footprint, ext, err := buildSACFootprintFromTemplate(
+		tmpl, tmplExt, asset,
+		mustAccountID(t, actualSrc.Address()),
+		mustAccountID(t, actualDst.Address()),
+	)
+	require.NoError(t, err)
+
+	// After filter + append: [contractInstance, actualSrcTrust, actualDstTrust].
+	require.Equal(t, []xdr.LedgerKey{
+		contractInstanceKey,
+		mustTrustlineKey(t, asset, actualSrc.Address()),
+		mustTrustlineKey(t, asset, actualDst.Address()),
+	}, footprint.ReadWrite)
+
+	// The archived index for the contract instance must move from 2 (its
+	// position in the template) to 0 (its position in the rewrite).
+	require.Equal(t, int32(1), int32(ext.V))
+	require.NotNil(t, ext.ResourceExt)
+	require.Equal(t, []xdr.Uint32{0}, ext.ResourceExt.ArchivedSorobanEntries)
+}
+
+// TestBuildSACFootprintFromTemplateDropsArchivedIndicesForFilteredEntries
+// verifies that archived indices pointing at template entries that get
+// dropped during the rewrite (per-asset trustlines) are silently filtered
+// from the returned extension. Classic trustlines aren't persistent and
+// can't be auto-restored anyway -- carrying a stale index would trip core's
+// "archivedSorobanEntries index points to a non-persistent entry" check.
+func TestBuildSACFootprintFromTemplateDropsArchivedIndicesForFilteredEntries(t *testing.T) {
+	issuer, err := keypair.Random()
+	require.NoError(t, err)
+	templateHolder, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+
+	asset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'B', 'L', 'T', 'C'},
+			Issuer:    mustAccountID(t, issuer.Address()),
+		},
+	}
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{
+			mustTrustlineKey(t, asset, templateHolder.Address()),
+		},
+	}
+	// Spurious archived index pointing at a trustline that the rewrite
+	// drops. Should be filtered out and the extension downgraded to V0.
+	tmplExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{0},
+		},
+	}
+	_, ext, err := buildSACFootprintFromTemplate(
+		tmpl, tmplExt, asset,
+		mustAccountID(t, actualSrc.Address()),
+		mustAccountID(t, actualDst.Address()),
+	)
+	require.NoError(t, err)
+	require.Equal(t, int32(0), int32(ext.V))
 }
 
 func TestBuildOZFootprintFromTemplateReplacesBalanceKeys(t *testing.T) {
@@ -115,7 +354,12 @@ func TestBuildOZFootprintFromTemplateReplacesBalanceKeys(t *testing.T) {
 		ReadOnly: []xdr.LedgerKey{{Type: xdr.LedgerEntryTypeAccount, Account: &xdr.LedgerKeyAccount{AccountId: readOnlyID}}},
 	}
 
-	footprint, err := buildOZFootprintFromTemplate(tmpl, contractID, src.Address(), dst.Address())
+	repSrcKey := mustBalanceKey(t, contractID, src.Address())
+	repDstKey := mustBalanceKey(t, contractID, dst.Address())
+	footprint, _, err := buildOZFootprintFromTemplate(
+		tmpl, xdr.SorobanTransactionDataExt{}, contractID,
+		src.Address(), dst.Address(), repSrcKey, repDstKey,
+	)
 	require.NoError(t, err)
 
 	expectedSrcKey := mustBalanceKey(t, contractID, src.Address())
@@ -126,9 +370,70 @@ func TestBuildOZFootprintFromTemplateReplacesBalanceKeys(t *testing.T) {
 
 func TestBuildOZFootprintFromTemplateReportsKeyErrors(t *testing.T) {
 	contractID := xdr.ContractId{1}
-	_, err := buildOZFootprintFromTemplate(xdr.LedgerFootprint{}, contractID, "not-an-address", "also-bad")
+	repSrc := xdr.LedgerKey{Type: xdr.LedgerEntryTypeAccount}
+	repDst := xdr.LedgerKey{Type: xdr.LedgerEntryTypeAccount}
+	_, _, err := buildOZFootprintFromTemplate(
+		xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, contractID,
+		"not-an-address", "also-bad", repSrc, repDst,
+	)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "src balance key")
+}
+
+// TestBuildOZFootprintFromTemplateRemapsArchivedSorobanEntries: when the
+// simulator's template RW contains the OZ contract instance entry (because
+// the instance is archived and needs autorestore), the bench's rewrite
+// drops the representative src/dst balance keys, keeps the instance entry,
+// and remaps the archivedSorobanEntries indices accordingly. Without this,
+// the index would point at one of the appended actual balance entries
+// (which IS persistent, so it'd "work" but autorestore the wrong entry) or
+// off the end of RW (out-of-bounds at submit).
+func TestBuildOZFootprintFromTemplateRemapsArchivedSorobanEntries(t *testing.T) {
+	repSrc, err := keypair.Random()
+	require.NoError(t, err)
+	repDst, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+	contractID := xdr.ContractId{1}
+
+	repSrcKey := mustBalanceKey(t, contractID, repSrc.Address())
+	repDstKey := mustBalanceKey(t, contractID, repDst.Address())
+	contractInstanceKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &xdr.ContractId{42},
+			},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{repSrcKey, repDstKey, contractInstanceKey},
+	}
+	tmplExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{2},
+		},
+	}
+
+	footprint, ext, err := buildOZFootprintFromTemplate(
+		tmpl, tmplExt, contractID,
+		actualSrc.Address(), actualDst.Address(), repSrcKey, repDstKey,
+	)
+	require.NoError(t, err)
+
+	expectedSrcKey := mustBalanceKey(t, contractID, actualSrc.Address())
+	expectedDstKey := mustBalanceKey(t, contractID, actualDst.Address())
+	require.Equal(t, []xdr.LedgerKey{contractInstanceKey, expectedSrcKey, expectedDstKey}, footprint.ReadWrite)
+	require.Equal(t, int32(1), int32(ext.V))
+	require.NotNil(t, ext.ResourceExt)
+	require.Equal(t, []xdr.Uint32{0}, ext.ResourceExt.ArchivedSorobanEntries)
 }
 
 func TestBuildSoroswapFootprintAddsTraderTrustlines(t *testing.T) {
@@ -197,6 +502,49 @@ func TestBuildSoroswapFootprintDoesNotDuplicateTrustlines(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, footprint.ReadWrite, 1)
 	require.Equal(t, mustTrustlineKey(t, asset, newTrader.Address()), footprint.ReadWrite[0])
+}
+
+func TestCompareSoroswapBenchmarkFootprintsAllowsExtraTrustlines(t *testing.T) {
+	trader, err := keypair.Random()
+	require.NoError(t, err)
+	issuer, err := keypair.Random()
+	require.NoError(t, err)
+
+	contractID := xdr.ContractId{1}
+	asset := xdr.Asset{
+		Type: xdr.AssetTypeAssetTypeCreditAlphanum4,
+		AlphaNum4: &xdr.AlphaNum4{
+			AssetCode: [4]byte{'U', 'S', 'D'},
+			Issuer:    mustAccountID(t, issuer.Address()),
+		},
+	}
+	simulated := xdr.LedgerFootprint{ReadWrite: []xdr.LedgerKey{mustBalanceKey(t, contractID, trader.Address())}}
+	benchmark := xdr.LedgerFootprint{ReadWrite: []xdr.LedgerKey{
+		mustBalanceKey(t, contractID, trader.Address()),
+		mustTrustlineKey(t, asset, trader.Address()),
+	}}
+
+	comparison, err := compareSoroswapBenchmarkFootprints(simulated, benchmark)
+	require.NoError(t, err)
+	require.False(t, comparison.hasMismatch())
+	require.Equal(t, 1, comparison.allowedExtraReadWriteKeys)
+}
+
+func TestCompareSoroswapBenchmarkFootprintsDetectsContractDataMismatch(t *testing.T) {
+	oldTrader, err := keypair.Random()
+	require.NoError(t, err)
+	newTrader, err := keypair.Random()
+	require.NoError(t, err)
+
+	contractID := xdr.ContractId{1}
+	simulated := xdr.LedgerFootprint{ReadWrite: []xdr.LedgerKey{mustBalanceKey(t, contractID, newTrader.Address())}}
+	benchmark := xdr.LedgerFootprint{ReadWrite: []xdr.LedgerKey{mustBalanceKey(t, contractID, oldTrader.Address())}}
+
+	comparison, err := compareSoroswapBenchmarkFootprints(simulated, benchmark)
+	require.NoError(t, err)
+	require.True(t, comparison.hasMismatch())
+	require.Equal(t, 1, comparison.missingReadWriteKeys)
+	require.Equal(t, 1, comparison.unexpectedReadWriteKeys)
 }
 
 func TestSoroswapResourcesForFootprintAddsManualHeadroom(t *testing.T) {

--- a/cmd/tx-load-test/benchmark/footprint_test.go
+++ b/cmd/tx-load-test/benchmark/footprint_test.go
@@ -436,6 +436,112 @@ func TestBuildOZFootprintFromTemplateRemapsArchivedSorobanEntries(t *testing.T) 
 	require.Equal(t, []xdr.Uint32{0}, ext.ResourceExt.ArchivedSorobanEntries)
 }
 
+// TestBuildOZFootprintFromTemplateInheritsArchivedBalanceMarkers is the
+// regression for the real OZ self-heal bug: the substituted entries (the
+// per-account balances) ARE the archived ones, and their autorestore markers
+// must transfer onto the appended actual src/dst balances. The prior remap
+// dropped them, so apply read an archived balance not in archivedSorobanEntries
+// and failed with invokeHostFunctionEntryArchived.
+func TestBuildOZFootprintFromTemplateInheritsArchivedBalanceMarkers(t *testing.T) {
+	repSrc, err := keypair.Random()
+	require.NoError(t, err)
+	repDst, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+	contractID := xdr.ContractId{1}
+
+	repSrcKey := mustBalanceKey(t, contractID, repSrc.Address())
+	repDstKey := mustBalanceKey(t, contractID, repDst.Address())
+	contractInstanceKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract: xdr.ScAddress{
+				Type:       xdr.ScAddressTypeScAddressTypeContract,
+				ContractId: &xdr.ContractId{42},
+			},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	// Template RW: [rep src bal, rep dst bal, instance]. The idle-state reality:
+	// ALL THREE are archived.
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{repSrcKey, repDstKey, contractInstanceKey},
+	}
+	tmplExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{0, 1, 2},
+		},
+	}
+
+	footprint, ext, err := buildOZFootprintFromTemplate(
+		tmpl, tmplExt, contractID,
+		actualSrc.Address(), actualDst.Address(), repSrcKey, repDstKey,
+	)
+	require.NoError(t, err)
+
+	// Rewritten RW: [instance, actual src bal, actual dst bal] at indices 0,1,2.
+	expectedSrcKey := mustBalanceKey(t, contractID, actualSrc.Address())
+	expectedDstKey := mustBalanceKey(t, contractID, actualDst.Address())
+	require.Equal(t, []xdr.LedgerKey{contractInstanceKey, expectedSrcKey, expectedDstKey}, footprint.ReadWrite)
+	// All three must be marked archived: instance (kept→0), actual src (1,
+	// inherited from rep src), actual dst (2, inherited from rep dst).
+	require.Equal(t, int32(1), int32(ext.V))
+	require.NotNil(t, ext.ResourceExt)
+	require.Equal(t, []xdr.Uint32{0, 1, 2}, ext.ResourceExt.ArchivedSorobanEntries)
+}
+
+// TestBuildOZFootprintFromTemplateInheritsOnlyArchivedBalances confirms the
+// inheritance is selective: when only the balances archived (not the instance),
+// only the appended balance indices are marked.
+func TestBuildOZFootprintFromTemplateInheritsOnlyArchivedBalances(t *testing.T) {
+	repSrc, err := keypair.Random()
+	require.NoError(t, err)
+	repDst, err := keypair.Random()
+	require.NoError(t, err)
+	actualSrc, err := keypair.Random()
+	require.NoError(t, err)
+	actualDst, err := keypair.Random()
+	require.NoError(t, err)
+	contractID := xdr.ContractId{1}
+
+	repSrcKey := mustBalanceKey(t, contractID, repSrc.Address())
+	repDstKey := mustBalanceKey(t, contractID, repDst.Address())
+	contractInstanceKey := xdr.LedgerKey{
+		Type: xdr.LedgerEntryTypeContractData,
+		ContractData: &xdr.LedgerKeyContractData{
+			Contract:   xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &xdr.ContractId{42}},
+			Key:        xdr.ScVal{Type: xdr.ScValTypeScvLedgerKeyContractInstance},
+			Durability: xdr.ContractDataDurabilityPersistent,
+		},
+	}
+	tmpl := xdr.LedgerFootprint{
+		ReadWrite: []xdr.LedgerKey{repSrcKey, repDstKey, contractInstanceKey},
+	}
+	// Only the balances (indices 0,1) are archived; the instance (2) is live.
+	tmplExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{0, 1},
+		},
+	}
+
+	_, ext, err := buildOZFootprintFromTemplate(
+		tmpl, tmplExt, contractID,
+		actualSrc.Address(), actualDst.Address(), repSrcKey, repDstKey,
+	)
+	require.NoError(t, err)
+	// Rewritten RW: [instance(0), actual src(1), actual dst(2)]. Instance not
+	// archived; the two appended balances are.
+	require.Equal(t, int32(1), int32(ext.V))
+	require.NotNil(t, ext.ResourceExt)
+	require.Equal(t, []xdr.Uint32{1, 2}, ext.ResourceExt.ArchivedSorobanEntries)
+}
+
 func TestBuildSoroswapFootprintAddsTraderTrustlines(t *testing.T) {
 	oldTrader, err := keypair.Random()
 	require.NoError(t, err)

--- a/cmd/tx-load-test/benchmark/metrics_report.go
+++ b/cmd/tx-load-test/benchmark/metrics_report.go
@@ -129,7 +129,7 @@ type byteMetricsReport struct {
 type flatMetricsRecord map[string]any
 
 func DefaultMetricsFileName(mode config.BenchmarkMode, now time.Time) string {
-	return fmt.Sprintf("tx-load-test-metrics-%s-%s.ndjson", now.UTC().Format("20060102T150405Z"), sanitizeFilenamePart(string(mode)))
+	return filepath.Join("metrics", fmt.Sprintf("tx-load-test-metrics-%s-%s.ndjson", now.UTC().Format("20060102T150405Z"), sanitizeFilenamePart(string(mode))))
 }
 
 func sanitizeFilenamePart(value string) string {

--- a/cmd/tx-load-test/benchmark/oz_transfer.go
+++ b/cmd/tx-load-test/benchmark/oz_transfer.go
@@ -237,10 +237,23 @@ func buildOZTransferInvokeArgs(contractID xdr.ContractId, srcAccID, dstAccID xdr
 
 // buildOZFootprintFromTemplate substitutes the per-request src/dst balance
 // keys for the representative ones the simulator saw. Non-balance template
-// RW entries (e.g. an autorestored OZ contract instance) are kept in place so
-// that protocol-23 autorestore indices still resolve at apply time; their
-// positions in the rewritten RW are tracked and the simulator's
-// archivedSorobanEntries are remapped accordingly.
+// RW entries (e.g. the OZ contract instance) are kept in place; the actual
+// src/dst balance entries are appended.
+//
+// Autorestore correctness hinges on a subtlety unique to OZ: unlike SAC and
+// soroswap -- whose substituted entries are classic trustlines that never
+// archive -- OZ's substituted entries ARE the per-account balance contract-data
+// entries, which DO archive. So when the simulator marks the representative
+// src/dst balances as archived, that marker must be INHERITED by the appended
+// actual src/dst balances; otherwise apply reads an archived balance that isn't
+// in archivedSorobanEntries and fails with invokeHostFunctionEntryArchived.
+// Kept entries (the instance) remap their indices as usual.
+//
+// This inherits the rep balances' archival state onto whichever accounts this
+// request happens to use. That is exact when balances age uniformly (all minted
+// together at setup, identical TTL) -- the same uniformity the template approach
+// already assumes. A per-request simulation would be exact in all cases but
+// defeats the template optimization.
 func buildOZFootprintFromTemplate(
 	tmpl xdr.LedgerFootprint,
 	tmplExt xdr.SorobanTransactionDataExt,
@@ -264,24 +277,61 @@ func buildOZFootprintFromTemplate(
 	if err != nil {
 		return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("marshal rep dst key: %w", err)
 	}
+
+	archivedTemplate := archivedTemplateIndexSet(tmplExt)
 	footprint := xdr.LedgerFootprint{
 		ReadOnly:  append([]xdr.LedgerKey(nil), tmpl.ReadOnly...),
 		ReadWrite: make([]xdr.LedgerKey, 0, len(tmpl.ReadWrite)+2),
 	}
-	indexRemap := make([]int, len(tmpl.ReadWrite))
+	var archived []xdr.Uint32
+	repSrcArchived, repDstArchived := false, false
 	for i, key := range tmpl.ReadWrite {
 		keyBytes, err := key.MarshalBinary()
 		if err != nil {
 			return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("marshal RW[%d]: %w", i, err)
 		}
-		if bytes.Equal(keyBytes, repSrcBytes) || bytes.Equal(keyBytes, repDstBytes) {
-			indexRemap[i] = -1
+		// The rep src/dst balances are dropped here and re-appended below as the
+		// actual accounts' keys; their archival state is carried onto the
+		// appended entries rather than the (now-absent) template positions.
+		if bytes.Equal(keyBytes, repSrcBytes) {
+			repSrcArchived = repSrcArchived || archivedTemplate[i]
 			continue
 		}
-		indexRemap[i] = len(footprint.ReadWrite)
+		if bytes.Equal(keyBytes, repDstBytes) {
+			repDstArchived = repDstArchived || archivedTemplate[i]
+			continue
+		}
+		newIdx := len(footprint.ReadWrite)
 		footprint.ReadWrite = append(footprint.ReadWrite, key)
+		if archivedTemplate[i] {
+			archived = append(archived, xdr.Uint32(newIdx))
+		}
 	}
-	footprint.ReadWrite = append(footprint.ReadWrite, srcKey, dstKey)
-	newExt := remapArchivedSorobanEntries(tmplExt, indexRemap)
-	return footprint, newExt, nil
+
+	srcIdx := len(footprint.ReadWrite)
+	footprint.ReadWrite = append(footprint.ReadWrite, srcKey)
+	if repSrcArchived {
+		archived = append(archived, xdr.Uint32(srcIdx))
+	}
+	dstIdx := len(footprint.ReadWrite)
+	footprint.ReadWrite = append(footprint.ReadWrite, dstKey)
+	if repDstArchived {
+		archived = append(archived, xdr.Uint32(dstIdx))
+	}
+
+	return footprint, buildArchivedSorobanExt(archived), nil
+}
+
+// archivedTemplateIndexSet returns the set of read-write footprint indices the
+// simulator marked for auto-restoration, for O(1) membership tests during a
+// footprint rewrite.
+func archivedTemplateIndexSet(ext xdr.SorobanTransactionDataExt) map[int]bool {
+	if ext.V != 1 || ext.ResourceExt == nil {
+		return nil
+	}
+	set := make(map[int]bool, len(ext.ResourceExt.ArchivedSorobanEntries))
+	for _, idx := range ext.ResourceExt.ArchivedSorobanEntries {
+		set[int(idx)] = true
+	}
+	return set
 }

--- a/cmd/tx-load-test/benchmark/oz_transfer.go
+++ b/cmd/tx-load-test/benchmark/oz_transfer.go
@@ -1,6 +1,7 @@
 package benchmark
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand/v2"
@@ -80,6 +81,19 @@ func (ozTransferMode) NewTargeter(ctx context.Context, rpcURL string, state *sta
 	if err != nil {
 		return nil, fmt.Errorf("pre-simulate OZ transfer: %w", err)
 	}
+	// Capture the representative src/dst keys so the per-request rewrite can
+	// drop them from the template's RW before appending the actual leased
+	// trader balance keys. Without this, every OZ tx would carry the
+	// representative src/dst entries plus the actual ones -- a duplicate-key
+	// rejection at submit and a stale-index autorestore signal at apply.
+	repSrcBalanceKey, err := ledger.OZBalanceLedgerKey(contractID, txSourceAccounts[0].Address())
+	if err != nil {
+		return nil, fmt.Errorf("encode OZ rep src balance key: %w", err)
+	}
+	repDstBalanceKey, err := ledger.OZBalanceLedgerKey(contractID, txSourceAccounts[1].Address())
+	if err != nil {
+		return nil, fmt.Errorf("encode OZ rep dst balance key: %w", err)
+	}
 
 	n := len(txSourceAccounts)
 
@@ -120,7 +134,13 @@ func (ozTransferMode) NewTargeter(ctx context.Context, rpcURL string, state *sta
 
 		invokeArgs := buildOZTransferInvokeArgs(contractID, srcAccID, dstAccID)
 
-		footprint, err := buildOZFootprintFromTemplate(simTemplate.simulation.Footprint, contractID, srcKP.Address(), dstKP.Address())
+		footprint, dataExt, err := buildOZFootprintFromTemplate(
+			simTemplate.simulation.Footprint,
+			simTemplate.simulation.Ext,
+			contractID,
+			srcKP.Address(), dstKP.Address(),
+			repSrcBalanceKey, repDstBalanceKey,
+		)
 		if err != nil {
 			return fmt.Errorf("build OZ footprint: %w", err)
 		}
@@ -150,6 +170,12 @@ func (ozTransferMode) NewTargeter(ctx context.Context, rpcURL string, state *sta
 				WriteBytes:    simTemplate.simulation.Resources.WriteBytes,
 			},
 			ResourceFee: simTemplate.simulation.ResourceFee,
+			// dataExt carries the remapped archivedSorobanEntries. The
+			// representative src/dst balance entries are filtered out before
+			// the new actual ones are appended, so any surviving simulator
+			// indices (e.g. the OZ contract instance when archived) are
+			// translated to their new positions and re-sorted.
+			SorobanDataExt: dataExt,
 		})
 		if err != nil {
 			return err
@@ -209,26 +235,53 @@ func buildOZTransferInvokeArgs(contractID xdr.ContractId, srcAccID, dstAccID xdr
 	}
 }
 
+// buildOZFootprintFromTemplate substitutes the per-request src/dst balance
+// keys for the representative ones the simulator saw. Non-balance template
+// RW entries (e.g. an autorestored OZ contract instance) are kept in place so
+// that protocol-23 autorestore indices still resolve at apply time; their
+// positions in the rewritten RW are tracked and the simulator's
+// archivedSorobanEntries are remapped accordingly.
 func buildOZFootprintFromTemplate(
 	tmpl xdr.LedgerFootprint,
+	tmplExt xdr.SorobanTransactionDataExt,
 	contractID xdr.ContractId,
 	srcAddress, dstAddress string,
-) (xdr.LedgerFootprint, error) {
-	return buildFootprintFromTemplate(
-		tmpl,
-		func() (xdr.LedgerKey, error) {
-			srcKey, err := ledger.OZBalanceLedgerKey(contractID, srcAddress)
-			if err != nil {
-				return xdr.LedgerKey{}, fmt.Errorf("src balance key: %w", err)
-			}
-			return srcKey, nil
-		},
-		func() (xdr.LedgerKey, error) {
-			dstKey, err := ledger.OZBalanceLedgerKey(contractID, dstAddress)
-			if err != nil {
-				return xdr.LedgerKey{}, fmt.Errorf("dst balance key: %w", err)
-			}
-			return dstKey, nil
-		},
-	)
+	repSrcKey, repDstKey xdr.LedgerKey,
+) (xdr.LedgerFootprint, xdr.SorobanTransactionDataExt, error) {
+	srcKey, err := ledger.OZBalanceLedgerKey(contractID, srcAddress)
+	if err != nil {
+		return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("src balance key: %w", err)
+	}
+	dstKey, err := ledger.OZBalanceLedgerKey(contractID, dstAddress)
+	if err != nil {
+		return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("dst balance key: %w", err)
+	}
+	repSrcBytes, err := repSrcKey.MarshalBinary()
+	if err != nil {
+		return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("marshal rep src key: %w", err)
+	}
+	repDstBytes, err := repDstKey.MarshalBinary()
+	if err != nil {
+		return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("marshal rep dst key: %w", err)
+	}
+	footprint := xdr.LedgerFootprint{
+		ReadOnly:  append([]xdr.LedgerKey(nil), tmpl.ReadOnly...),
+		ReadWrite: make([]xdr.LedgerKey, 0, len(tmpl.ReadWrite)+2),
+	}
+	indexRemap := make([]int, len(tmpl.ReadWrite))
+	for i, key := range tmpl.ReadWrite {
+		keyBytes, err := key.MarshalBinary()
+		if err != nil {
+			return xdr.LedgerFootprint{}, xdr.SorobanTransactionDataExt{}, fmt.Errorf("marshal RW[%d]: %w", i, err)
+		}
+		if bytes.Equal(keyBytes, repSrcBytes) || bytes.Equal(keyBytes, repDstBytes) {
+			indexRemap[i] = -1
+			continue
+		}
+		indexRemap[i] = len(footprint.ReadWrite)
+		footprint.ReadWrite = append(footprint.ReadWrite, key)
+	}
+	footprint.ReadWrite = append(footprint.ReadWrite, srcKey, dstKey)
+	newExt := remapArchivedSorobanEntries(tmplExt, indexRemap)
+	return footprint, newExt, nil
 }

--- a/cmd/tx-load-test/benchmark/oz_transfer.go
+++ b/cmd/tx-load-test/benchmark/oz_transfer.go
@@ -118,33 +118,7 @@ func (ozTransferMode) NewTargeter(ctx context.Context, rpcURL string, state *sta
 			return fmt.Errorf("parse dst account: %w", err)
 		}
 
-		invokeArgs := xdr.InvokeContractArgs{
-			ContractAddress: xdr.ScAddress{
-				Type:       xdr.ScAddressTypeScAddressTypeContract,
-				ContractId: &contractID,
-			},
-			FunctionName: "transfer",
-			Args: xdr.ScVec{
-				{
-					Type: xdr.ScValTypeScvAddress,
-					Address: &xdr.ScAddress{
-						Type:      xdr.ScAddressTypeScAddressTypeAccount,
-						AccountId: &srcAccID,
-					},
-				},
-				{
-					Type: xdr.ScValTypeScvAddress,
-					Address: &xdr.ScAddress{
-						Type:      xdr.ScAddressTypeScAddressTypeAccount,
-						AccountId: &dstAccID,
-					},
-				},
-				{
-					Type: xdr.ScValTypeScvI128,
-					I128: &xdr.Int128Parts{Hi: 0, Lo: xdr.Uint64(sacTransferAmount)},
-				},
-			},
-		}
+		invokeArgs := buildOZTransferInvokeArgs(contractID, srcAccID, dstAccID)
 
 		footprint, err := buildOZFootprintFromTemplate(simTemplate.simulation.Footprint, contractID, srcKP.Address(), dstKP.Address())
 		if err != nil {
@@ -200,7 +174,13 @@ func presimulateOZTransfer(
 		return simulatedInvocationTemplate{}, err
 	}
 
-	invokeArgs := xdr.InvokeContractArgs{
+	invokeArgs := buildOZTransferInvokeArgs(contractID, srcAccID, dstAccID)
+
+	return presimulateBenchmarkInvocation(state, srcKP, srcKP.Address(), invokeArgs)
+}
+
+func buildOZTransferInvokeArgs(contractID xdr.ContractId, srcAccID, dstAccID xdr.AccountId) xdr.InvokeContractArgs {
+	return xdr.InvokeContractArgs{
 		ContractAddress: xdr.ScAddress{
 			Type:       xdr.ScAddressTypeScAddressTypeContract,
 			ContractId: &contractID,
@@ -227,8 +207,6 @@ func presimulateOZTransfer(
 			},
 		},
 	}
-
-	return presimulateBenchmarkInvocation(state, srcKP, srcKP.Address(), invokeArgs)
 }
 
 func buildOZFootprintFromTemplate(

--- a/cmd/tx-load-test/benchmark/poll_client.go
+++ b/cmd/tx-load-test/benchmark/poll_client.go
@@ -1,0 +1,55 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+)
+
+type transactionPollClient interface {
+	GetTransactions(ctx context.Context, requests []transactionPollRequest) ([]transactionPollAttemptResult, error)
+}
+
+type transactionPollRequest struct {
+	ID   int64
+	Hash string
+}
+
+type transactionPollAttemptResult struct {
+	ID       int64
+	Hash     string
+	Response protocol.GetTransactionResponse
+	Err      error
+}
+
+type sdkTransactionPollClient struct {
+	rpc *rpcclient.Client
+}
+
+func newSDKTransactionPollClient(rpc *rpcclient.Client) sdkTransactionPollClient {
+	return sdkTransactionPollClient{rpc: rpc}
+}
+
+func (c sdkTransactionPollClient) GetTransactions(ctx context.Context, requests []transactionPollRequest) ([]transactionPollAttemptResult, error) {
+	if c.rpc == nil {
+		return nil, fmt.Errorf("missing RPC client")
+	}
+
+	results := make([]transactionPollAttemptResult, len(requests))
+	for i, request := range requests {
+		result := transactionPollAttemptResult{ID: request.ID, Hash: request.Hash}
+		if err := ctx.Err(); err != nil {
+			result.Err = err
+			results[i] = result
+			continue
+		}
+
+		resp, err := c.rpc.GetTransaction(ctx, protocol.GetTransactionRequest{Hash: request.Hash})
+		result.Response = resp
+		result.Err = err
+		results[i] = result
+	}
+	return results, nil
+}

--- a/cmd/tx-load-test/benchmark/poll_client.go
+++ b/cmd/tx-load-test/benchmark/poll_client.go
@@ -12,6 +12,16 @@ type transactionPollClient interface {
 	GetTransactions(ctx context.Context, requests []transactionPollRequest) ([]transactionPollAttemptResult, error)
 }
 
+// latestLedgerObserver fetches the current network ledger sequence and its
+// close time. The poll scheduler's ledger-advance gate uses this only as a
+// fallback to keep the shared ledger clock advancing when poll traffic dies
+// down (the drain tail); in steady state the clock is kept fresh for free from
+// getTransaction responses. A poll client that implements this enables the
+// fallback ticker; one that does not (e.g. test fakes) simply runs without it.
+type latestLedgerObserver interface {
+	GetLatestLedgerSeq(ctx context.Context) (sequence uint32, closeUnix int64, err error)
+}
+
 type transactionPollRequest struct {
 	ID   int64
 	Hash string
@@ -30,6 +40,21 @@ type sdkTransactionPollClient struct {
 
 func newSDKTransactionPollClient(rpc *rpcclient.Client) sdkTransactionPollClient {
 	return sdkTransactionPollClient{rpc: rpc}
+}
+
+// GetLatestLedgerSeq returns the current network ledger sequence and close
+// time. Note the underlying getLatestLedger response also carries the full
+// ledger metadata XDR, which we deliberately ignore -- we only read the
+// sequence and close time. The fallback ticker keeps this call rare.
+func (c sdkTransactionPollClient) GetLatestLedgerSeq(ctx context.Context) (uint32, int64, error) {
+	if c.rpc == nil {
+		return 0, 0, fmt.Errorf("missing RPC client")
+	}
+	resp, err := c.rpc.GetLatestLedger(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	return resp.Sequence, resp.LedgerCloseTime, nil
 }
 
 func (c sdkTransactionPollClient) GetTransactions(ctx context.Context, requests []transactionPollRequest) ([]transactionPollAttemptResult, error) {

--- a/cmd/tx-load-test/benchmark/restore.go
+++ b/cmd/tx-load-test/benchmark/restore.go
@@ -1,0 +1,481 @@
+package benchmark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/ledger"
+	sharedsoroban "github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/soroban"
+	sharedsoroswap "github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/soroswap"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
+)
+
+const RestoreModeAll = "all"
+
+const restoreMaxLoggedErrors = 5
+const defaultRestoreProgressInterval = 100
+
+type RestoreOptions struct {
+	Mode         string
+	DryRun       bool
+	Verify       bool
+	AccountStart int
+	AccountLimit int
+	// ProgressInterval controls how often long restore scans log progress. A
+	// value of 0 uses the default; a negative value disables periodic progress.
+	ProgressInterval int
+}
+
+type restoreSummary struct {
+	mode                config.BenchmarkMode
+	dryRun              bool
+	accountStart        int
+	accountEnd          int
+	selectedAccounts    int
+	probes              int
+	restoreNeededProbes int
+	restoreTransactions int
+	noopProbes          int
+	readOnlyKeys        int
+	readWriteKeys       int
+	resourceFee         xdr.Int64
+	totalProbes         int
+	progressInterval    int
+	logger              *log.Entry
+	startedAt           time.Time
+	errors              []error
+}
+
+type restoreProbeFunc func(
+	context.Context,
+	*state.State,
+	*keypair.Full,
+	string,
+	xdr.InvokeContractArgs,
+	int64,
+	sharedsoroban.RestoreProbeOptions,
+) (sharedsoroban.RestoreProbeResult, error)
+
+var restoreInvokeContract = sharedsoroban.RestoreInvokeContract
+var restoreSoroswapTokenBalance = sharedsoroswap.TokenBalance
+
+type soroswapRestoreProbe struct {
+	inputToken  string
+	outputToken string
+	amountIn    int64
+}
+
+func RestoreArchivedState(ctx context.Context, logger *log.Entry, st *state.State, options RestoreOptions) error {
+	if st == nil || st.FeePayerKP == nil {
+		return fmt.Errorf("restore state missing fee payer keypair")
+	}
+	if options.AccountStart < 0 {
+		return fmt.Errorf("account-start must be >= 0")
+	}
+	if options.AccountLimit < 0 {
+		return fmt.Errorf("account-limit must be >= 0")
+	}
+
+	modesToRestore, err := restoreModes(options.Mode)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, mode := range modesToRestore {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+		summary, err := restoreMode(ctx, logger, st, mode, options)
+		logRestoreSummary(logger, summary)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("mode=%s: %w", mode, err))
+		}
+		if options.Verify && err == nil && !options.DryRun && ctx.Err() == nil {
+			verifyOptions := options
+			verifyOptions.DryRun = true
+			verifySummary, verifyErr := restoreMode(ctx, logger, st, mode, verifyOptions)
+			verifySummary.dryRun = false
+			logRestoreVerifySummary(logger, verifySummary)
+			if verifyErr != nil {
+				errs = append(errs, fmt.Errorf("mode=%s verify: %w", mode, verifyErr))
+			} else if verifySummary.restoreNeededProbes > 0 {
+				errs = append(errs, fmt.Errorf("mode=%s verify: %d probes still require restore", mode, verifySummary.restoreNeededProbes))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func restoreModes(mode string) ([]config.BenchmarkMode, error) {
+	if mode == "" || mode == RestoreModeAll {
+		return append([]config.BenchmarkMode(nil), supportedModes...), nil
+	}
+	benchmarkMode := config.BenchmarkMode(mode)
+	if _, ok := modes[benchmarkMode]; !ok {
+		return nil, fmt.Errorf("unknown restore mode: %q", mode)
+	}
+	return []config.BenchmarkMode{benchmarkMode}, nil
+}
+
+func restoreMode(ctx context.Context, logger *log.Entry, st *state.State, mode config.BenchmarkMode, options RestoreOptions) (restoreSummary, error) {
+	summary := restoreSummary{
+		mode:             mode,
+		dryRun:           options.DryRun,
+		progressInterval: normalizeRestoreProgressInterval(options.ProgressInterval),
+		logger:           logger,
+		startedAt:        time.Now(),
+	}
+	switch mode {
+	case config.ModeSACTransfer:
+		return restoreSACContracts(ctx, st, options, summary)
+	case config.ModeOZTransfer:
+		return restoreOZBalances(ctx, st, options, summary)
+	case config.ModeSoroswap:
+		return restoreSoroswap(ctx, st, options, summary)
+	default:
+		summary.addError(fmt.Errorf("unknown restore mode: %q", mode))
+		return summary, summary.error()
+	}
+}
+
+func restoreSACContracts(ctx context.Context, st *state.State, _ RestoreOptions, summary restoreSummary) (restoreSummary, error) {
+	if len(st.SACs) == 0 {
+		summary.addError(fmt.Errorf("state has no SAC contracts"))
+		return summary, summary.error()
+	}
+	summary.accountStart = 0
+	summary.accountEnd = 0
+	summary.selectedAccounts = 0
+	summary.totalProbes = len(st.SACs)
+	summary.logStart("restore mode started")
+	for i, contract := range st.SACs {
+		if contract == "" {
+			summary.addError(fmt.Errorf("missing SAC contract[%d]", i))
+			continue
+		}
+		contractID, err := ledger.DecodeContractID(contract)
+		if err != nil {
+			summary.addError(fmt.Errorf("decode SAC contract[%d]: %w", i, err))
+			continue
+		}
+		invokeArgs := xdr.InvokeContractArgs{
+			ContractAddress: xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
+			FunctionName:    "decimals",
+		}
+		if !summary.recordProbe(ctx, st, st.FeePayerKP, st.FeePayerKP.Address(), invokeArgs) {
+			return summary, summary.error()
+		}
+	}
+	return summary, summary.error()
+}
+
+func restoreOZBalances(ctx context.Context, st *state.State, options RestoreOptions, summary restoreSummary) (restoreSummary, error) {
+	if st.OZTokenContract == "" {
+		summary.addError(fmt.Errorf("state missing OZ token contract"))
+		return summary, summary.error()
+	}
+	if len(st.AccountKPs) < 2 {
+		summary.addError(fmt.Errorf("need at least 2 participant accounts for OZ restore, got %d", len(st.AccountKPs)))
+		return summary, summary.error()
+	}
+	contractID, err := ledger.DecodeContractID(st.OZTokenContract)
+	if err != nil {
+		summary.addError(fmt.Errorf("decode OZ token contract ID: %w", err))
+		return summary, summary.error()
+	}
+	accounts, start, end, err := selectAccountRange(st.AccountKPs, options.AccountStart, options.AccountLimit)
+	if err != nil {
+		summary.addError(err)
+		return summary, summary.error()
+	}
+	summary.accountStart = start
+	summary.accountEnd = end
+	summary.selectedAccounts = len(accounts)
+	summary.totalProbes = len(accounts)
+	summary.logStart("restore mode started")
+	for _, srcKP := range accounts {
+		dstKP := firstDifferentAccount(st.AccountKPs, srcKP.Address())
+		if dstKP == nil {
+			summary.addError(fmt.Errorf("no destination account available for %s", srcKP.Address()))
+			continue
+		}
+		srcAccID, err := xdr.AddressToAccountId(srcKP.Address())
+		if err != nil {
+			summary.addError(fmt.Errorf("parse OZ source account %s: %w", srcKP.Address(), err))
+			continue
+		}
+		dstAccID, err := xdr.AddressToAccountId(dstKP.Address())
+		if err != nil {
+			summary.addError(fmt.Errorf("parse OZ destination account %s: %w", dstKP.Address(), err))
+			continue
+		}
+		if !summary.recordProbe(ctx, st, srcKP, srcKP.Address(), buildOZTransferInvokeArgs(contractID, srcAccID, dstAccID)) {
+			return summary, summary.error()
+		}
+	}
+	return summary, summary.error()
+}
+
+func restoreSoroswap(ctx context.Context, st *state.State, options RestoreOptions, summary restoreSummary) (restoreSummary, error) {
+	if st.SoroswapFactoryContract == "" {
+		summary.addError(fmt.Errorf("state missing Soroswap factory contract"))
+		return summary, summary.error()
+	}
+	if st.SoroswapRouterContract == "" {
+		summary.addError(fmt.Errorf("state missing Soroswap router contract"))
+		return summary, summary.error()
+	}
+	if len(st.SoroswapPairContracts) != len(sharedsoroswap.BenchmarkPairs) {
+		summary.addError(fmt.Errorf("need %d Soroswap pair contracts, got %d", len(sharedsoroswap.BenchmarkPairs), len(st.SoroswapPairContracts)))
+		return summary, summary.error()
+	}
+	routerID, err := ledger.DecodeContractID(st.SoroswapRouterContract)
+	if err != nil {
+		summary.addError(fmt.Errorf("decode Soroswap router contract ID: %w", err))
+		return summary, summary.error()
+	}
+	holders := st.SACHolderKPs
+	if len(holders) == 0 {
+		holders = state.DefaultSACHolderKPs(st.AccountKPs)
+	}
+	if len(holders) == 0 {
+		summary.addError(fmt.Errorf("need at least 1 holder account for Soroswap restore"))
+		return summary, summary.error()
+	}
+	accounts, start, end, err := selectAccountRange(holders, options.AccountStart, options.AccountLimit)
+	if err != nil {
+		summary.addError(err)
+		return summary, summary.error()
+	}
+	summary.accountStart = start
+	summary.accountEnd = end
+	summary.selectedAccounts = len(accounts)
+	summary.totalProbes = len(accounts) * len(sharedsoroswap.BenchmarkPairs) * 2
+	summary.logStart("restore mode started")
+	deadline := uint64(time.Now().Add(soroswapSwapDeadlineWindow).Unix())
+	probes := make([]soroswapRestoreProbe, 0, len(sharedsoroswap.BenchmarkPairs)*2)
+
+	for i, pair := range sharedsoroswap.BenchmarkPairs {
+		if err := ctx.Err(); err != nil {
+			summary.addError(err)
+			return summary, summary.error()
+		}
+		pairContract := st.SoroswapPairContracts[i]
+		tokenA := st.SACs[pair[0]]
+		tokenB := st.SACs[pair[1]]
+		if tokenA == "" || tokenB == "" || pairContract == "" {
+			summary.addError(fmt.Errorf("soroswap pool %d is missing token or pair contract state", i))
+			continue
+		}
+		reserveA, err := restoreSoroswapTokenBalance(ctx, st, tokenA, pairContract)
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d reserve A: %w", i, err))
+			continue
+		}
+		reserveB, err := restoreSoroswapTokenBalance(ctx, st, tokenB, pairContract)
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d reserve B: %w", i, err))
+			continue
+		}
+		probes = append(probes,
+			soroswapRestoreProbe{inputToken: tokenA, outputToken: tokenB, amountIn: sharedsoroswap.SwapAmount(reserveA)},
+			soroswapRestoreProbe{inputToken: tokenB, outputToken: tokenA, amountIn: sharedsoroswap.SwapAmount(reserveB)},
+		)
+	}
+	if len(probes) == 0 {
+		if summary.error() == nil {
+			summary.addError(fmt.Errorf("no Soroswap restore probes available"))
+		}
+		return summary, summary.error()
+	}
+	summary.totalProbes = len(accounts) * len(probes)
+	for _, trader := range accounts {
+		for _, probe := range probes {
+			if !summary.recordSoroswapProbe(ctx, st, routerID, trader, probe, deadline) {
+				return summary, summary.error()
+			}
+		}
+	}
+	return summary, summary.error()
+}
+
+func (s *restoreSummary) recordSoroswapProbe(ctx context.Context, st *state.State, routerID xdr.ContractId, trader *keypair.Full, probe soroswapRestoreProbe, deadline uint64) bool {
+	invokeArgs, err := sharedsoroswap.BuildSwapInvokeArgs(routerID, trader.Address(), probe.inputToken, probe.outputToken, probe.amountIn, deadline)
+	if err != nil {
+		s.addError(fmt.Errorf("build Soroswap restore probe for %s: %w", trader.Address(), err))
+		return true
+	}
+	return s.recordProbe(ctx, st, trader, trader.Address(), invokeArgs)
+}
+
+func (s *restoreSummary) recordProbe(ctx context.Context, st *state.State, txSourceKP *keypair.Full, opSourceAddress string, invokeArgs xdr.InvokeContractArgs) bool {
+	if err := ctx.Err(); err != nil {
+		s.addError(err)
+		s.logProgress(s.probes, "restore progress")
+		return false
+	}
+	s.probes++
+	probeNumber := s.probes
+	result, err := restoreInvokeContract(ctx, st, txSourceKP, opSourceAddress, invokeArgs, benchmarkBaseFeeMin, sharedsoroban.RestoreProbeOptions{
+		DryRun:    s.dryRun,
+		PadFactor: resourcePadFactor,
+	})
+	if err != nil {
+		s.addError(err)
+		s.logProgress(probeNumber, "restore progress")
+		return ctx.Err() == nil
+	}
+	if result.RestoreNeeded {
+		s.restoreNeededProbes++
+	} else {
+		s.noopProbes++
+	}
+	s.restoreTransactions += result.RestoreTransactions
+	s.readOnlyKeys += result.ReadOnlyKeys
+	s.readWriteKeys += result.ReadWriteKeys
+	s.resourceFee += result.ResourceFee
+	s.logProgress(probeNumber, "restore progress")
+	if err := ctx.Err(); err != nil {
+		s.addError(err)
+		return false
+	}
+	return true
+}
+
+func normalizeRestoreProgressInterval(interval int) int {
+	if interval == 0 {
+		return defaultRestoreProgressInterval
+	}
+	return interval
+}
+
+func selectAccountRange(accounts []*keypair.Full, start, limit int) ([]*keypair.Full, int, int, error) {
+	if start < 0 {
+		return nil, 0, 0, fmt.Errorf("account-start must be >= 0")
+	}
+	if limit < 0 {
+		return nil, 0, 0, fmt.Errorf("account-limit must be >= 0")
+	}
+	if start >= len(accounts) {
+		return nil, start, start, fmt.Errorf("account-start %d is outside account pool of size %d", start, len(accounts))
+	}
+	end := len(accounts)
+	if limit > 0 && start+limit < end {
+		end = start + limit
+	}
+	return accounts[start:end], start, end, nil
+}
+
+func firstDifferentAccount(accounts []*keypair.Full, address string) *keypair.Full {
+	for _, kp := range accounts {
+		if kp != nil && kp.Address() != address {
+			return kp
+		}
+	}
+	return nil
+}
+
+func (s *restoreSummary) addError(err error) {
+	if err == nil {
+		return
+	}
+	s.errors = append(s.errors, err)
+}
+
+func (s restoreSummary) error() error {
+	return errors.Join(s.errors...)
+}
+
+func (s restoreSummary) logStart(message string) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.WithFields(log.F{
+		"mode":             s.mode,
+		"dryRun":           s.dryRun,
+		"accountStart":     s.accountStart,
+		"accountEnd":       s.accountEnd,
+		"selectedAccounts": s.selectedAccounts,
+		"totalProbes":      s.totalProbes,
+		"progressInterval": s.progressInterval,
+	}).Info(message)
+}
+
+func (s restoreSummary) logProgress(probeNumber int, message string) {
+	if s.logger == nil || s.progressInterval < 0 {
+		return
+	}
+	if probeNumber != 1 && probeNumber != s.totalProbes && (s.progressInterval == 0 || probeNumber%s.progressInterval != 0) {
+		return
+	}
+	s.logger.WithFields(log.F{
+		"mode":                s.mode,
+		"dryRun":              s.dryRun,
+		"probes":              s.probes,
+		"totalProbes":         s.totalProbes,
+		"restoreNeededProbes": s.restoreNeededProbes,
+		"restoreTransactions": s.restoreTransactions,
+		"noopProbes":          s.noopProbes,
+		"readOnlyKeys":        s.readOnlyKeys,
+		"readWriteKeys":       s.readWriteKeys,
+		"errors":              len(s.errors),
+		"elapsed":             time.Since(s.startedAt).String(),
+	}).Info(message)
+}
+
+func logRestoreSummary(logger *log.Entry, summary restoreSummary) {
+	if logger == nil {
+		return
+	}
+	fields := log.F{
+		"mode":                summary.mode,
+		"dryRun":              summary.dryRun,
+		"probes":              summary.probes,
+		"restoreNeededProbes": summary.restoreNeededProbes,
+		"restoreTransactions": summary.restoreTransactions,
+		"noopProbes":          summary.noopProbes,
+		"readOnlyKeys":        summary.readOnlyKeys,
+		"readWriteKeys":       summary.readWriteKeys,
+		"resourceFee":         summary.resourceFee,
+		"totalProbes":         summary.totalProbes,
+		"accountStart":        summary.accountStart,
+		"accountEnd":          summary.accountEnd,
+		"selectedAccounts":    summary.selectedAccounts,
+		"elapsed":             time.Since(summary.startedAt).String(),
+		"errors":              len(summary.errors),
+	}
+	entry := logger.WithFields(fields)
+	for i, err := range summary.errors {
+		if i >= restoreMaxLoggedErrors {
+			break
+		}
+		entry = entry.WithField(fmt.Sprintf("error%d", i+1), err.Error())
+	}
+	if summary.dryRun {
+		entry.Info("restore dry-run summary: would restore archived state where needed")
+		return
+	}
+	entry.Info("restore summary")
+}
+
+func logRestoreVerifySummary(logger *log.Entry, summary restoreSummary) {
+	if logger == nil {
+		return
+	}
+	logger.WithFields(log.F{
+		"mode":                summary.mode,
+		"probes":              summary.probes,
+		"restoreNeededProbes": summary.restoreNeededProbes,
+		"noopProbes":          summary.noopProbes,
+		"errors":              len(summary.errors),
+	}).Info("restore verification summary")
+}

--- a/cmd/tx-load-test/benchmark/restore.go
+++ b/cmd/tx-load-test/benchmark/restore.go
@@ -46,11 +46,20 @@ type restoreSummary struct {
 	readOnlyKeys        int
 	readWriteKeys       int
 	resourceFee         xdr.Int64
-	totalProbes         int
-	progressInterval    int
-	logger              *log.Entry
-	startedAt           time.Time
-	errors              []error
+	// autoRestoreProbes counts probes whose simulator reported no legacy
+	// RestorePreamble but did emit SorobanResourcesExtV0.ArchivedSorobanEntries
+	// (protocol-23+ autorestore). These probes don't submit a separate
+	// RestoreFootprint -- the invoking tx pays for inline restoration via the
+	// extension -- but they ARE indicative that read-write contract data is
+	// archived. Splitting them out keeps restoreTransactions honest while
+	// surfacing the count operators need to see.
+	autoRestoreProbes int
+	autoRestoreKeys   int
+	totalProbes       int
+	progressInterval  int
+	logger            *log.Entry
+	startedAt         time.Time
+	errors            []error
 }
 
 type restoreProbeFunc func(
@@ -70,6 +79,54 @@ type soroswapRestoreProbe struct {
 	inputToken  string
 	outputToken string
 	amountIn    int64
+}
+
+type soroswapBenchmarkValidationProbe struct {
+	pairIndex   int
+	direction   string
+	inputToken  string
+	outputToken string
+	inputAsset  xdr.Asset
+	outputAsset xdr.Asset
+	amountIn    int64
+}
+
+type soroswapBenchmarkFootprintValidationSummary struct {
+	dryRun                    bool
+	accountStart              int
+	accountEnd                int
+	selectedAccounts          int
+	templateProbes            int
+	templates                 int
+	benchmarkProbes           int
+	totalBenchmarkProbes      int
+	restoreNeededProbes       int
+	footprintMismatches       int
+	missingReadOnlyKeys       int
+	missingReadWriteKeys      int
+	unexpectedReadOnlyKeys    int
+	unexpectedReadWriteKeys   int
+	allowedExtraReadWriteKeys int
+	skippedBenchmarkProbes    int
+	progressInterval          int
+	logger                    *log.Entry
+	startedAt                 time.Time
+	errorCount                int
+	errors                    []error
+}
+
+type soroswapFootprintComparison struct {
+	missingReadOnlyKeys       int
+	missingReadWriteKeys      int
+	unexpectedReadOnlyKeys    int
+	unexpectedReadWriteKeys   int
+	allowedExtraReadWriteKeys int
+}
+
+type encodedFootprint struct {
+	readOnly  map[string]xdr.LedgerKey
+	readWrite map[string]xdr.LedgerKey
+	any       map[string]xdr.LedgerKey
 }
 
 func RestoreArchivedState(ctx context.Context, logger *log.Entry, st *state.State, options RestoreOptions) error {
@@ -96,10 +153,18 @@ func RestoreArchivedState(ctx context.Context, logger *log.Entry, st *state.Stat
 		}
 		summary, err := restoreMode(ctx, logger, st, mode, options)
 		logRestoreSummary(logger, summary)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("mode=%s: %w", mode, err))
+		modeErr := err
+		if modeErr == nil && mode == config.ModeSoroswap && ctx.Err() == nil {
+			validationSummary, validationErr := validateSoroswapBenchmarkFootprints(ctx, logger, st, options)
+			logSoroswapBenchmarkFootprintValidationSummary(logger, validationSummary)
+			if validationErr != nil {
+				modeErr = fmt.Errorf("benchmark footprint validation: %w", validationErr)
+			}
 		}
-		if options.Verify && err == nil && !options.DryRun && ctx.Err() == nil {
+		if modeErr != nil {
+			errs = append(errs, fmt.Errorf("mode=%s: %w", mode, modeErr))
+		}
+		if options.Verify && modeErr == nil && !options.DryRun && ctx.Err() == nil {
 			verifyOptions := options
 			verifyOptions.DryRun = true
 			verifySummary, verifyErr := restoreMode(ctx, logger, st, mode, verifyOptions)
@@ -107,8 +172,14 @@ func RestoreArchivedState(ctx context.Context, logger *log.Entry, st *state.Stat
 			logRestoreVerifySummary(logger, verifySummary)
 			if verifyErr != nil {
 				errs = append(errs, fmt.Errorf("mode=%s verify: %w", mode, verifyErr))
-			} else if verifySummary.restoreNeededProbes > 0 {
-				errs = append(errs, fmt.Errorf("mode=%s verify: %d probes still require restore", mode, verifySummary.restoreNeededProbes))
+			} else if remaining := verifySummary.restoreNeededProbes - verifySummary.autoRestoreProbes; remaining > 0 {
+				// Autorestore probes intentionally aren't followed by a
+				// RestoreFootprint tx -- the bench's invocations will pay
+				// for inline restoration via SorobanResourcesExtV0. So they
+				// will keep showing up on every verify pass and aren't an
+				// error here. Only legacy RestorePreamble probes that still
+				// require restoration after a real restore run are.
+				errs = append(errs, fmt.Errorf("mode=%s verify: %d probes still require restore", mode, remaining))
 			}
 		}
 	}
@@ -147,32 +218,58 @@ func restoreMode(ctx context.Context, logger *log.Entry, st *state.State, mode c
 	}
 }
 
-func restoreSACContracts(ctx context.Context, st *state.State, _ RestoreOptions, summary restoreSummary) (restoreSummary, error) {
+func restoreSACContracts(ctx context.Context, st *state.State, options RestoreOptions, summary restoreSummary) (restoreSummary, error) {
 	if len(st.SACs) == 0 {
 		summary.addError(fmt.Errorf("state has no SAC contracts"))
 		return summary, summary.error()
 	}
-	summary.accountStart = 0
-	summary.accountEnd = 0
-	summary.selectedAccounts = 0
-	summary.totalProbes = len(st.SACs)
+	holders := st.SACHolderKPs
+	if len(holders) == 0 {
+		holders = state.DefaultSACHolderKPs(st.AccountKPs)
+	}
+	if len(holders) < 2 {
+		summary.addError(fmt.Errorf("need at least 2 holder accounts for SAC restore, got %d", len(holders)))
+		return summary, summary.error()
+	}
+	accounts, start, end, err := selectAccountRange(holders, options.AccountStart, options.AccountLimit)
+	if err != nil {
+		summary.addError(err)
+		return summary, summary.error()
+	}
+	summary.accountStart = start
+	summary.accountEnd = end
+	summary.selectedAccounts = len(accounts)
+	summary.totalProbes = len(accounts) * len(st.SACs)
 	summary.logStart("restore mode started")
-	for i, contract := range st.SACs {
-		if contract == "" {
-			summary.addError(fmt.Errorf("missing SAC contract[%d]", i))
+	for _, srcKP := range accounts {
+		dstKP := firstDifferentAccount(holders, srcKP.Address())
+		if dstKP == nil {
+			summary.addError(fmt.Errorf("no destination holder account available for %s", srcKP.Address()))
 			continue
 		}
-		contractID, err := ledger.DecodeContractID(contract)
+		srcAccID, err := xdr.AddressToAccountId(srcKP.Address())
 		if err != nil {
-			summary.addError(fmt.Errorf("decode SAC contract[%d]: %w", i, err))
+			summary.addError(fmt.Errorf("parse SAC restore source account %s: %w", srcKP.Address(), err))
 			continue
 		}
-		invokeArgs := xdr.InvokeContractArgs{
-			ContractAddress: xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
-			FunctionName:    "decimals",
+		dstAccID, err := xdr.AddressToAccountId(dstKP.Address())
+		if err != nil {
+			summary.addError(fmt.Errorf("parse SAC restore destination account %s: %w", dstKP.Address(), err))
+			continue
 		}
-		if !summary.recordProbe(ctx, st, st.FeePayerKP, st.FeePayerKP.Address(), invokeArgs) {
-			return summary, summary.error()
+		for i, contract := range st.SACs {
+			if contract == "" {
+				summary.addError(fmt.Errorf("missing SAC contract[%d]", i))
+				continue
+			}
+			contractID, err := ledger.DecodeContractID(contract)
+			if err != nil {
+				summary.addError(fmt.Errorf("decode SAC contract[%d]: %w", i, err))
+				continue
+			}
+			if !summary.recordProbe(ctx, st, srcKP, srcKP.Address(), buildSACTransferInvokeArgs(contractID, srcAccID, dstAccID)) {
+				return summary, summary.error()
+			}
 		}
 	}
 	return summary, summary.error()
@@ -243,10 +340,7 @@ func restoreSoroswap(ctx context.Context, st *state.State, options RestoreOption
 		summary.addError(fmt.Errorf("decode Soroswap router contract ID: %w", err))
 		return summary, summary.error()
 	}
-	holders := st.SACHolderKPs
-	if len(holders) == 0 {
-		holders = state.DefaultSACHolderKPs(st.AccountKPs)
-	}
+	holders := soroswapHolderAccounts(st)
 	if len(holders) == 0 {
 		summary.addError(fmt.Errorf("need at least 1 holder account for Soroswap restore"))
 		return summary, summary.error()
@@ -308,6 +402,411 @@ func restoreSoroswap(ctx context.Context, st *state.State, options RestoreOption
 	return summary, summary.error()
 }
 
+func soroswapHolderAccounts(st *state.State) []*keypair.Full {
+	holders := st.SACHolderKPs
+	if len(holders) == 0 {
+		holders = state.DefaultSACHolderKPs(st.AccountKPs)
+	}
+	return holders
+}
+
+func validateSoroswapBenchmarkFootprints(ctx context.Context, logger *log.Entry, st *state.State, options RestoreOptions) (soroswapBenchmarkFootprintValidationSummary, error) {
+	summary := soroswapBenchmarkFootprintValidationSummary{
+		dryRun:           options.DryRun,
+		progressInterval: normalizeRestoreProgressInterval(options.ProgressInterval),
+		logger:           logger,
+		startedAt:        time.Now(),
+	}
+	if st.SoroswapRouterContract == "" {
+		summary.addError(fmt.Errorf("state missing Soroswap router contract"))
+		return summary, summary.error()
+	}
+	if len(st.SoroswapPairContracts) != len(sharedsoroswap.BenchmarkPairs) {
+		summary.addError(fmt.Errorf("need %d Soroswap pair contracts, got %d", len(sharedsoroswap.BenchmarkPairs), len(st.SoroswapPairContracts)))
+		return summary, summary.error()
+	}
+	routerID, err := ledger.DecodeContractID(st.SoroswapRouterContract)
+	if err != nil {
+		summary.addError(fmt.Errorf("decode Soroswap router contract ID: %w", err))
+		return summary, summary.error()
+	}
+	holders := soroswapHolderAccounts(st)
+	if len(holders) == 0 {
+		summary.addError(fmt.Errorf("need at least 1 holder account for Soroswap benchmark footprint validation"))
+		return summary, summary.error()
+	}
+	accounts, start, end, err := selectAccountRange(holders, options.AccountStart, options.AccountLimit)
+	if err != nil {
+		summary.addError(err)
+		return summary, summary.error()
+	}
+	summary.accountStart = start
+	summary.accountEnd = end
+	summary.selectedAccounts = len(accounts)
+
+	probes := buildSoroswapBenchmarkValidationProbes(ctx, st, &summary)
+	summary.totalBenchmarkProbes = len(accounts) * len(probes)
+	summary.logStart("soroswap benchmark footprint validation started")
+	if len(probes) == 0 {
+		if summary.error() == nil {
+			summary.addError(fmt.Errorf("no Soroswap benchmark footprint validation probes available"))
+		}
+		return summary, summary.error()
+	}
+
+	deadline := uint64(time.Now().Add(soroswapSwapDeadlineWindow).Unix())
+	representativeTrader := holders[0]
+	templates := make([]soroswapSwapTemplate, 0, len(probes))
+	for _, probe := range probes {
+		tmpl, ok := summary.recordSoroswapBenchmarkTemplate(ctx, st, routerID, representativeTrader, probe, deadline)
+		if ok {
+			templates = append(templates, tmpl)
+		}
+		if err := ctx.Err(); err != nil {
+			summary.addError(err)
+			return summary, summary.error()
+		}
+	}
+	summary.templates = len(templates)
+	summary.skippedBenchmarkProbes = len(accounts) * (len(probes) - len(templates))
+	if len(templates) == 0 {
+		return summary, summary.error()
+	}
+
+	for _, trader := range accounts {
+		for templateIdx, tmpl := range templates {
+			if !summary.recordSoroswapBenchmarkFootprint(ctx, st, trader, tmpl, templateIdx) {
+				return summary, summary.error()
+			}
+		}
+	}
+	return summary, summary.error()
+}
+
+func buildSoroswapBenchmarkValidationProbes(ctx context.Context, st *state.State, summary *soroswapBenchmarkFootprintValidationSummary) []soroswapBenchmarkValidationProbe {
+	probes := make([]soroswapBenchmarkValidationProbe, 0, len(sharedsoroswap.BenchmarkPairs)*2)
+	for i, pair := range sharedsoroswap.BenchmarkPairs {
+		if err := ctx.Err(); err != nil {
+			summary.addError(err)
+			return probes
+		}
+		pairContract := st.SoroswapPairContracts[i]
+		tokenA := st.SACs[pair[0]]
+		tokenB := st.SACs[pair[1]]
+		if tokenA == "" || tokenB == "" || pairContract == "" {
+			summary.addError(fmt.Errorf("soroswap pool %d is missing token or pair contract state", i))
+			continue
+		}
+		assetA, err := st.Assets[pair[0]].ToXDR()
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d asset A to XDR: %w", i, err))
+			continue
+		}
+		assetB, err := st.Assets[pair[1]].ToXDR()
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d asset B to XDR: %w", i, err))
+			continue
+		}
+		reserveA, err := restoreSoroswapTokenBalance(ctx, st, tokenA, pairContract)
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d reserve A: %w", i, err))
+			continue
+		}
+		reserveB, err := restoreSoroswapTokenBalance(ctx, st, tokenB, pairContract)
+		if err != nil {
+			summary.addError(fmt.Errorf("pool %d reserve B: %w", i, err))
+			continue
+		}
+		probes = append(probes,
+			soroswapBenchmarkValidationProbe{
+				pairIndex:   i,
+				direction:   "A->B",
+				inputToken:  tokenA,
+				outputToken: tokenB,
+				inputAsset:  assetA,
+				outputAsset: assetB,
+				amountIn:    sharedsoroswap.SwapAmount(reserveA),
+			},
+			soroswapBenchmarkValidationProbe{
+				pairIndex:   i,
+				direction:   "B->A",
+				inputToken:  tokenB,
+				outputToken: tokenA,
+				inputAsset:  assetB,
+				outputAsset: assetA,
+				amountIn:    sharedsoroswap.SwapAmount(reserveB),
+			},
+		)
+	}
+	return probes
+}
+
+func (s *soroswapBenchmarkFootprintValidationSummary) recordSoroswapBenchmarkTemplate(
+	ctx context.Context,
+	st *state.State,
+	routerID xdr.ContractId,
+	representativeTrader *keypair.Full,
+	probe soroswapBenchmarkValidationProbe,
+	deadline uint64,
+) (soroswapSwapTemplate, bool) {
+	if err := ctx.Err(); err != nil {
+		s.addError(err)
+		return soroswapSwapTemplate{}, false
+	}
+	s.templateProbes++
+	invokeArgs, err := sharedsoroswap.BuildSwapInvokeArgs(routerID, representativeTrader.Address(), probe.inputToken, probe.outputToken, probe.amountIn, deadline)
+	if err != nil {
+		s.addError(fmt.Errorf("build Soroswap benchmark template probe pair=%d direction=%s: %w", probe.pairIndex, probe.direction, err))
+		return soroswapSwapTemplate{}, false
+	}
+	result, err := restoreInvokeContract(ctx, st, representativeTrader, representativeTrader.Address(), invokeArgs, benchmarkBaseFeeMin, sharedsoroban.RestoreProbeOptions{
+		DryRun:    true,
+		PadFactor: resourcePadFactor,
+	})
+	if err != nil {
+		s.addError(fmt.Errorf("simulate Soroswap benchmark template pair=%d direction=%s: %w", probe.pairIndex, probe.direction, err))
+		return soroswapSwapTemplate{}, false
+	}
+	if result.RestoreNeeded {
+		s.restoreNeededProbes++
+		return soroswapSwapTemplate{}, false
+	}
+	if !result.HasSimulation {
+		s.addError(fmt.Errorf("simulate Soroswap benchmark template pair=%d direction=%s returned no simulation", probe.pairIndex, probe.direction))
+		return soroswapSwapTemplate{}, false
+	}
+	return soroswapSwapTemplate{
+		traderAddress: representativeTrader.Address(),
+		inputAsset:    probe.inputAsset,
+		outputAsset:   probe.outputAsset,
+		simulatedInvocationTemplate: simulatedInvocationTemplate{
+			invokeArgs: invokeArgs,
+			simulation: result.Simulation,
+		},
+	}, true
+}
+
+func (s *soroswapBenchmarkFootprintValidationSummary) recordSoroswapBenchmarkFootprint(
+	ctx context.Context,
+	st *state.State,
+	trader *keypair.Full,
+	tmpl soroswapSwapTemplate,
+	templateIdx int,
+) bool {
+	if err := ctx.Err(); err != nil {
+		s.addError(err)
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return false
+	}
+	s.benchmarkProbes++
+	invokeArgs, err := sharedsoroswap.RewriteInvokeContractAccount(tmpl.invokeArgs, tmpl.traderAddress, trader.Address())
+	if err != nil {
+		s.addError(fmt.Errorf("rewrite Soroswap benchmark invoke args for %s template=%d: %w", trader.Address(), templateIdx, err))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+	if _, err := sharedsoroswap.RewriteSorobanAuthEntriesAccount(tmpl.simulation.AuthEntries, tmpl.traderAddress, trader.Address()); err != nil {
+		s.addError(fmt.Errorf("rewrite Soroswap benchmark auth for %s template=%d: %w", trader.Address(), templateIdx, err))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+	benchmarkFootprint, err := buildSoroswapFootprint(tmpl.simulation.Footprint, tmpl.traderAddress, trader.Address(), tmpl.inputAsset, tmpl.outputAsset)
+	if err != nil {
+		s.addError(fmt.Errorf("build Soroswap benchmark footprint for %s template=%d: %w", trader.Address(), templateIdx, err))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+	_, _ = soroswapResourcesForFootprint(tmpl.simulation, benchmarkFootprint)
+
+	result, err := restoreInvokeContract(ctx, st, trader, trader.Address(), invokeArgs, benchmarkBaseFeeMin, sharedsoroban.RestoreProbeOptions{
+		DryRun:    true,
+		PadFactor: resourcePadFactor,
+	})
+	if err != nil {
+		s.addError(fmt.Errorf("simulate Soroswap benchmark validation probe for %s template=%d: %w", trader.Address(), templateIdx, err))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return ctx.Err() == nil
+	}
+	if result.RestoreNeeded {
+		s.restoreNeededProbes++
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+	if !result.HasSimulation {
+		s.addError(fmt.Errorf("simulate Soroswap benchmark validation probe for %s template=%d returned no simulation", trader.Address(), templateIdx))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+
+	comparison, err := compareSoroswapBenchmarkFootprints(result.Simulation.Footprint, benchmarkFootprint)
+	if err != nil {
+		s.addError(fmt.Errorf("compare Soroswap benchmark footprint for %s template=%d: %w", trader.Address(), templateIdx, err))
+		s.logProgress("soroswap benchmark footprint validation progress")
+		return true
+	}
+	s.missingReadOnlyKeys += comparison.missingReadOnlyKeys
+	s.missingReadWriteKeys += comparison.missingReadWriteKeys
+	s.unexpectedReadOnlyKeys += comparison.unexpectedReadOnlyKeys
+	s.unexpectedReadWriteKeys += comparison.unexpectedReadWriteKeys
+	s.allowedExtraReadWriteKeys += comparison.allowedExtraReadWriteKeys
+	if comparison.hasMismatch() {
+		s.footprintMismatches++
+		s.addError(fmt.Errorf(
+			"Soroswap benchmark footprint mismatch for %s template=%d: missingReadOnly=%d missingReadWrite=%d unexpectedReadOnly=%d unexpectedReadWrite=%d",
+			trader.Address(),
+			templateIdx,
+			comparison.missingReadOnlyKeys,
+			comparison.missingReadWriteKeys,
+			comparison.unexpectedReadOnlyKeys,
+			comparison.unexpectedReadWriteKeys,
+		))
+	}
+	s.logProgress("soroswap benchmark footprint validation progress")
+	if err := ctx.Err(); err != nil {
+		s.addError(err)
+		return false
+	}
+	return true
+}
+
+func compareSoroswapBenchmarkFootprints(simulated xdr.LedgerFootprint, benchmark xdr.LedgerFootprint) (soroswapFootprintComparison, error) {
+	simulatedKeys, err := encodeFootprint(simulated)
+	if err != nil {
+		return soroswapFootprintComparison{}, fmt.Errorf("encode simulated footprint: %w", err)
+	}
+	benchmarkKeys, err := encodeFootprint(benchmark)
+	if err != nil {
+		return soroswapFootprintComparison{}, fmt.Errorf("encode benchmark footprint: %w", err)
+	}
+
+	var comparison soroswapFootprintComparison
+	for encoded := range simulatedKeys.readOnly {
+		if _, ok := benchmarkKeys.any[encoded]; !ok {
+			comparison.missingReadOnlyKeys++
+		}
+	}
+	for encoded := range simulatedKeys.readWrite {
+		if _, ok := benchmarkKeys.readWrite[encoded]; !ok {
+			comparison.missingReadWriteKeys++
+		}
+	}
+	for encoded := range benchmarkKeys.readOnly {
+		if _, ok := simulatedKeys.any[encoded]; !ok {
+			comparison.unexpectedReadOnlyKeys++
+		}
+	}
+	for encoded, key := range benchmarkKeys.readWrite {
+		if _, ok := simulatedKeys.any[encoded]; ok {
+			continue
+		}
+		if key.Type == xdr.LedgerEntryTypeTrustline {
+			comparison.allowedExtraReadWriteKeys++
+			continue
+		}
+		comparison.unexpectedReadWriteKeys++
+	}
+	return comparison, nil
+}
+
+func encodeFootprint(footprint xdr.LedgerFootprint) (encodedFootprint, error) {
+	encoded := encodedFootprint{
+		readOnly:  make(map[string]xdr.LedgerKey, len(footprint.ReadOnly)),
+		readWrite: make(map[string]xdr.LedgerKey, len(footprint.ReadWrite)),
+		any:       make(map[string]xdr.LedgerKey, len(footprint.ReadOnly)+len(footprint.ReadWrite)),
+	}
+	for _, key := range footprint.ReadOnly {
+		keyID, err := xdr.MarshalBase64(key)
+		if err != nil {
+			return encodedFootprint{}, err
+		}
+		encoded.readOnly[keyID] = key
+		encoded.any[keyID] = key
+	}
+	for _, key := range footprint.ReadWrite {
+		keyID, err := xdr.MarshalBase64(key)
+		if err != nil {
+			return encodedFootprint{}, err
+		}
+		encoded.readWrite[keyID] = key
+		encoded.any[keyID] = key
+	}
+	return encoded, nil
+}
+
+func (c soroswapFootprintComparison) hasMismatch() bool {
+	return c.missingReadOnlyKeys > 0 ||
+		c.missingReadWriteKeys > 0 ||
+		c.unexpectedReadOnlyKeys > 0 ||
+		c.unexpectedReadWriteKeys > 0
+}
+
+func (s *soroswapBenchmarkFootprintValidationSummary) addError(err error) {
+	if err == nil {
+		return
+	}
+	s.errorCount++
+	if len(s.errors) >= restoreMaxLoggedErrors {
+		return
+	}
+	s.errors = append(s.errors, err)
+}
+
+func (s soroswapBenchmarkFootprintValidationSummary) error() error {
+	var errs []error
+	if len(s.errors) > 0 {
+		errs = append(errs, errors.Join(s.errors...))
+	}
+	if !s.dryRun && s.restoreNeededProbes > 0 {
+		errs = append(errs, fmt.Errorf("%d Soroswap benchmark footprint validation probes still require restore", s.restoreNeededProbes))
+	}
+	if s.footprintMismatches > 0 && len(s.errors) == 0 {
+		errs = append(errs, fmt.Errorf("%d Soroswap benchmark footprint validation probes mismatched fresh simulation", s.footprintMismatches))
+	}
+	return errors.Join(errs...)
+}
+
+func (s soroswapBenchmarkFootprintValidationSummary) logStart(message string) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.WithFields(log.F{
+		"mode":                 config.ModeSoroswap,
+		"dryRun":               s.dryRun,
+		"accountStart":         s.accountStart,
+		"accountEnd":           s.accountEnd,
+		"selectedAccounts":     s.selectedAccounts,
+		"totalBenchmarkProbes": s.totalBenchmarkProbes,
+		"progressInterval":     s.progressInterval,
+	}).Info(message)
+}
+
+func (s soroswapBenchmarkFootprintValidationSummary) logProgress(message string) {
+	if s.logger == nil || s.progressInterval < 0 {
+		return
+	}
+	if s.benchmarkProbes != 1 && s.benchmarkProbes != s.totalBenchmarkProbes && (s.progressInterval == 0 || s.benchmarkProbes%s.progressInterval != 0) {
+		return
+	}
+	s.logger.WithFields(log.F{
+		"mode":                      config.ModeSoroswap,
+		"dryRun":                    s.dryRun,
+		"templateProbes":            s.templateProbes,
+		"templates":                 s.templates,
+		"benchmarkProbes":           s.benchmarkProbes,
+		"totalBenchmarkProbes":      s.totalBenchmarkProbes,
+		"restoreNeededProbes":       s.restoreNeededProbes,
+		"footprintMismatches":       s.footprintMismatches,
+		"missingReadOnlyKeys":       s.missingReadOnlyKeys,
+		"missingReadWriteKeys":      s.missingReadWriteKeys,
+		"unexpectedReadOnlyKeys":    s.unexpectedReadOnlyKeys,
+		"unexpectedReadWriteKeys":   s.unexpectedReadWriteKeys,
+		"allowedExtraReadWriteKeys": s.allowedExtraReadWriteKeys,
+		"skippedBenchmarkProbes":    s.skippedBenchmarkProbes,
+		"errors":                    s.errorCount,
+		"elapsed":                   time.Since(s.startedAt).String(),
+	}).Info(message)
+}
+
 func (s *restoreSummary) recordSoroswapProbe(ctx context.Context, st *state.State, routerID xdr.ContractId, trader *keypair.Full, probe soroswapRestoreProbe, deadline uint64) bool {
 	invokeArgs, err := sharedsoroswap.BuildSwapInvokeArgs(routerID, trader.Address(), probe.inputToken, probe.outputToken, probe.amountIn, deadline)
 	if err != nil {
@@ -338,6 +837,10 @@ func (s *restoreSummary) recordProbe(ctx context.Context, st *state.State, txSou
 		s.restoreNeededProbes++
 	} else {
 		s.noopProbes++
+	}
+	if result.AutoRestoreKeys > 0 {
+		s.autoRestoreProbes++
+		s.autoRestoreKeys += result.AutoRestoreKeys
 	}
 	s.restoreTransactions += result.RestoreTransactions
 	s.readOnlyKeys += result.ReadOnlyKeys
@@ -424,6 +927,8 @@ func (s restoreSummary) logProgress(probeNumber int, message string) {
 		"totalProbes":         s.totalProbes,
 		"restoreNeededProbes": s.restoreNeededProbes,
 		"restoreTransactions": s.restoreTransactions,
+		"autoRestoreProbes":   s.autoRestoreProbes,
+		"autoRestoreKeys":     s.autoRestoreKeys,
 		"noopProbes":          s.noopProbes,
 		"readOnlyKeys":        s.readOnlyKeys,
 		"readWriteKeys":       s.readWriteKeys,
@@ -442,6 +947,8 @@ func logRestoreSummary(logger *log.Entry, summary restoreSummary) {
 		"probes":              summary.probes,
 		"restoreNeededProbes": summary.restoreNeededProbes,
 		"restoreTransactions": summary.restoreTransactions,
+		"autoRestoreProbes":   summary.autoRestoreProbes,
+		"autoRestoreKeys":     summary.autoRestoreKeys,
 		"noopProbes":          summary.noopProbes,
 		"readOnlyKeys":        summary.readOnlyKeys,
 		"readWriteKeys":       summary.readWriteKeys,
@@ -467,6 +974,41 @@ func logRestoreSummary(logger *log.Entry, summary restoreSummary) {
 	entry.Info("restore summary")
 }
 
+func logSoroswapBenchmarkFootprintValidationSummary(logger *log.Entry, summary soroswapBenchmarkFootprintValidationSummary) {
+	if logger == nil {
+		return
+	}
+	fields := log.F{
+		"mode":                      config.ModeSoroswap,
+		"dryRun":                    summary.dryRun,
+		"templateProbes":            summary.templateProbes,
+		"templates":                 summary.templates,
+		"benchmarkProbes":           summary.benchmarkProbes,
+		"totalBenchmarkProbes":      summary.totalBenchmarkProbes,
+		"restoreNeededProbes":       summary.restoreNeededProbes,
+		"footprintMismatches":       summary.footprintMismatches,
+		"missingReadOnlyKeys":       summary.missingReadOnlyKeys,
+		"missingReadWriteKeys":      summary.missingReadWriteKeys,
+		"unexpectedReadOnlyKeys":    summary.unexpectedReadOnlyKeys,
+		"unexpectedReadWriteKeys":   summary.unexpectedReadWriteKeys,
+		"allowedExtraReadWriteKeys": summary.allowedExtraReadWriteKeys,
+		"skippedBenchmarkProbes":    summary.skippedBenchmarkProbes,
+		"accountStart":              summary.accountStart,
+		"accountEnd":                summary.accountEnd,
+		"selectedAccounts":          summary.selectedAccounts,
+		"elapsed":                   time.Since(summary.startedAt).String(),
+		"errors":                    summary.errorCount,
+	}
+	entry := logger.WithFields(fields)
+	for i, err := range summary.errors {
+		if i >= restoreMaxLoggedErrors {
+			break
+		}
+		entry = entry.WithField(fmt.Sprintf("error%d", i+1), err.Error())
+	}
+	entry.Info("soroswap benchmark footprint validation summary")
+}
+
 func logRestoreVerifySummary(logger *log.Entry, summary restoreSummary) {
 	if logger == nil {
 		return
@@ -475,6 +1017,8 @@ func logRestoreVerifySummary(logger *log.Entry, summary restoreSummary) {
 		"mode":                summary.mode,
 		"probes":              summary.probes,
 		"restoreNeededProbes": summary.restoreNeededProbes,
+		"autoRestoreProbes":   summary.autoRestoreProbes,
+		"autoRestoreKeys":     summary.autoRestoreKeys,
 		"noopProbes":          summary.noopProbes,
 		"errors":              len(summary.errors),
 	}).Info("restore verification summary")

--- a/cmd/tx-load-test/benchmark/restore_test.go
+++ b/cmd/tx-load-test/benchmark/restore_test.go
@@ -1,0 +1,255 @@
+package benchmark
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/network"
+	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/ledger"
+	sharedsoroban "github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/soroban"
+	sharedsoroswap "github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/soroswap"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
+)
+
+func TestSelectAccountRange(t *testing.T) {
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t), mustRandomKP(t), mustRandomKP(t)}
+
+	selected, start, end, err := selectAccountRange(accounts, 1, 2)
+	require.NoError(t, err)
+	require.Equal(t, 1, start)
+	require.Equal(t, 3, end)
+	require.Equal(t, accounts[1:3], selected)
+
+	selected, start, end, err = selectAccountRange(accounts, 2, 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, start)
+	require.Equal(t, 4, end)
+	require.Equal(t, accounts[2:], selected)
+
+	_, _, _, err = selectAccountRange(accounts, 4, 0)
+	require.ErrorContains(t, err, "outside account pool")
+}
+
+func TestRestoreSACContractsProbesContractInstancesOnly(t *testing.T) {
+	oldProbe := restoreInvokeContract
+	defer func() { restoreInvokeContract = oldProbe }()
+
+	var calls []xdr.InvokeContractArgs
+	restoreInvokeContract = func(
+		_ context.Context,
+		_ *state.State,
+		_ *keypair.Full,
+		_ string,
+		invokeArgs xdr.InvokeContractArgs,
+		_ int64,
+		_ sharedsoroban.RestoreProbeOptions,
+	) (sharedsoroban.RestoreProbeResult, error) {
+		calls = append(calls, invokeArgs)
+		return sharedsoroban.RestoreProbeResult{}, nil
+	}
+
+	st := &state.State{
+		FeePayerKP:        mustRandomKP(t),
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		SACs:              [3]string{mustContractID(t, 1), mustContractID(t, 2), mustContractID(t, 3)},
+	}
+	summary, err := restoreSACContracts(context.Background(), st, RestoreOptions{DryRun: true}, restoreSummary{
+		mode:      config.ModeSACTransfer,
+		dryRun:    true,
+		startedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, summary.probes)
+	require.Len(t, calls, 3)
+	for _, call := range calls {
+		require.Equal(t, xdr.ScSymbol("decimals"), call.FunctionName)
+		require.Empty(t, call.Args)
+	}
+}
+
+func TestRestoreDryRunLogsPerModeSummary(t *testing.T) {
+	oldProbe := restoreInvokeContract
+	defer func() { restoreInvokeContract = oldProbe }()
+
+	restoreInvokeContract = func(
+		_ context.Context,
+		_ *state.State,
+		_ *keypair.Full,
+		_ string,
+		invokeArgs xdr.InvokeContractArgs,
+		_ int64,
+		options sharedsoroban.RestoreProbeOptions,
+	) (sharedsoroban.RestoreProbeResult, error) {
+		require.True(t, options.DryRun)
+		return sharedsoroban.RestoreProbeResult{
+			RestoreNeeded: true,
+			ReadOnlyKeys:  1,
+			ReadWriteKeys: 2,
+			ResourceFee:   3,
+		}, nil
+	}
+
+	var buf bytes.Buffer
+	logger := log.New()
+	logger.SetLevel(log.InfoLevel)
+	logger.SetOutput(&buf)
+	logger.DisableColors()
+	logger.DisableTimestamp()
+
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t)}
+	st := &state.State{
+		FeePayerKP:        mustRandomKP(t),
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		AccountKPs:        accounts,
+		OZTokenContract:   mustContractID(t, 4),
+	}
+	err := RestoreArchivedState(context.Background(), logger, st, RestoreOptions{
+		Mode:             string(config.ModeOZTransfer),
+		DryRun:           true,
+		AccountLimit:     2,
+		ProgressInterval: 1,
+	})
+	require.NoError(t, err)
+
+	output := buf.String()
+	require.Contains(t, output, "restore mode started")
+	require.Contains(t, output, "restore progress")
+	require.Contains(t, output, "restore dry-run summary: would restore archived state where needed")
+	require.Contains(t, output, "mode=oz-transfer")
+	require.Contains(t, output, "totalProbes=2")
+	require.Contains(t, output, "probes=2")
+	require.Contains(t, output, "restoreNeededProbes=2")
+	require.Contains(t, output, "restoreTransactions=0")
+	require.Contains(t, output, "readOnlyKeys=2")
+	require.Contains(t, output, "readWriteKeys=4")
+	require.False(t, strings.Contains(output, "restore summary\n"), output)
+}
+
+func TestRestoreAccountLimitAppliesPerModeAccountSelection(t *testing.T) {
+	oldProbe := restoreInvokeContract
+	oldTokenBalance := restoreSoroswapTokenBalance
+	defer func() {
+		restoreInvokeContract = oldProbe
+		restoreSoroswapTokenBalance = oldTokenBalance
+	}()
+
+	var soroswapAmounts []xdr.Uint64
+	restoreInvokeContract = func(
+		_ context.Context,
+		_ *state.State,
+		_ *keypair.Full,
+		_ string,
+		invokeArgs xdr.InvokeContractArgs,
+		_ int64,
+		_ sharedsoroban.RestoreProbeOptions,
+	) (sharedsoroban.RestoreProbeResult, error) {
+		if invokeArgs.FunctionName == "swap_exact_tokens_for_tokens" {
+			amount, ok := invokeArgs.Args[0].GetI128()
+			require.True(t, ok)
+			soroswapAmounts = append(soroswapAmounts, amount.Lo)
+		}
+		return sharedsoroban.RestoreProbeResult{}, nil
+	}
+	restoreSoroswapTokenBalance = func(context.Context, *state.State, string, string) (xdr.Int128Parts, error) {
+		return xdr.Int128Parts{Hi: 0, Lo: 1_000_000}, nil
+	}
+
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t), mustRandomKP(t), mustRandomKP(t)}
+	st := &state.State{
+		FeePayerKP:              mustRandomKP(t),
+		NetworkPassphrase:       network.TestNetworkPassphrase,
+		AccountKPs:              accounts,
+		SACHolderKPs:            accounts,
+		SACs:                    [3]string{mustContractID(t, 1), mustContractID(t, 2), mustContractID(t, 3)},
+		OZTokenContract:         mustContractID(t, 4),
+		SoroswapFactoryContract: mustContractID(t, 5),
+		SoroswapRouterContract:  mustContractID(t, 6),
+		SoroswapPairContracts:   []string{mustContractID(t, 7), mustContractID(t, 8)},
+	}
+
+	ozSummary, err := restoreOZBalances(context.Background(), st, RestoreOptions{AccountLimit: 2, DryRun: true}, restoreSummary{
+		mode:      config.ModeOZTransfer,
+		dryRun:    true,
+		startedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, ozSummary.selectedAccounts)
+	require.Equal(t, 2, ozSummary.totalProbes)
+	require.Equal(t, 2, ozSummary.probes)
+
+	soroswapSummary, err := restoreSoroswap(context.Background(), st, RestoreOptions{AccountLimit: 2, DryRun: true}, restoreSummary{
+		mode:      config.ModeSoroswap,
+		dryRun:    true,
+		startedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, soroswapSummary.selectedAccounts)
+	require.Equal(t, 2*len(sharedsoroswap.BenchmarkPairs)*2, soroswapSummary.totalProbes)
+	require.Equal(t, soroswapSummary.totalProbes, soroswapSummary.probes)
+	require.Len(t, soroswapAmounts, soroswapSummary.probes)
+	for _, amount := range soroswapAmounts {
+		require.Equal(t, xdr.Uint64(1000), amount)
+	}
+}
+
+func TestRestoreStopsAfterContextCancellation(t *testing.T) {
+	oldProbe := restoreInvokeContract
+	defer func() { restoreInvokeContract = oldProbe }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	probeCalls := 0
+	restoreInvokeContract = func(
+		_ context.Context,
+		_ *state.State,
+		_ *keypair.Full,
+		_ string,
+		_ xdr.InvokeContractArgs,
+		_ int64,
+		_ sharedsoroban.RestoreProbeOptions,
+	) (sharedsoroban.RestoreProbeResult, error) {
+		probeCalls++
+		cancel()
+		return sharedsoroban.RestoreProbeResult{}, nil
+	}
+
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t), mustRandomKP(t), mustRandomKP(t)}
+	st := &state.State{
+		FeePayerKP:        mustRandomKP(t),
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		AccountKPs:        accounts,
+		OZTokenContract:   mustContractID(t, 4),
+	}
+	summary, err := restoreOZBalances(ctx, st, RestoreOptions{AccountLimit: 4, DryRun: true}, restoreSummary{
+		mode:      config.ModeOZTransfer,
+		dryRun:    true,
+		startedAt: time.Now(),
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, probeCalls)
+	require.Equal(t, 1, summary.probes)
+}
+
+func mustRandomKP(t *testing.T) *keypair.Full {
+	t.Helper()
+	kp, err := keypair.Random()
+	require.NoError(t, err)
+	return kp
+}
+
+func mustContractID(t *testing.T, marker byte) string {
+	t.Helper()
+	var id xdr.ContractId
+	id[0] = marker
+	encoded, err := ledger.EncodeContractID(id)
+	require.NoError(t, err)
+	return encoded
+}

--- a/cmd/tx-load-test/benchmark/restore_test.go
+++ b/cmd/tx-load-test/benchmark/restore_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/network"
 	"github.com/stellar/go-stellar-sdk/support/log"
+	"github.com/stellar/go-stellar-sdk/txnbuild"
 	"github.com/stellar/go-stellar-sdk/xdr"
 	"github.com/stretchr/testify/require"
 
@@ -39,27 +40,34 @@ func TestSelectAccountRange(t *testing.T) {
 	require.ErrorContains(t, err, "outside account pool")
 }
 
-func TestRestoreSACContractsProbesContractInstancesOnly(t *testing.T) {
+func TestRestoreSACContractsProbesTransferPath(t *testing.T) {
 	oldProbe := restoreInvokeContract
 	defer func() { restoreInvokeContract = oldProbe }()
 
 	var calls []xdr.InvokeContractArgs
+	var txSources []string
+	var opSources []string
 	restoreInvokeContract = func(
 		_ context.Context,
 		_ *state.State,
-		_ *keypair.Full,
-		_ string,
+		txSourceKP *keypair.Full,
+		opSourceAddress string,
 		invokeArgs xdr.InvokeContractArgs,
 		_ int64,
 		_ sharedsoroban.RestoreProbeOptions,
 	) (sharedsoroban.RestoreProbeResult, error) {
 		calls = append(calls, invokeArgs)
+		txSources = append(txSources, txSourceKP.Address())
+		opSources = append(opSources, opSourceAddress)
 		return sharedsoroban.RestoreProbeResult{}, nil
 	}
 
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t)}
 	st := &state.State{
 		FeePayerKP:        mustRandomKP(t),
 		NetworkPassphrase: network.TestNetworkPassphrase,
+		AccountKPs:        accounts,
+		SACHolderKPs:      accounts,
 		SACs:              [3]string{mustContractID(t, 1), mustContractID(t, 2), mustContractID(t, 3)},
 	}
 	summary, err := restoreSACContracts(context.Background(), st, RestoreOptions{DryRun: true}, restoreSummary{
@@ -68,11 +76,28 @@ func TestRestoreSACContractsProbesContractInstancesOnly(t *testing.T) {
 		startedAt: time.Now(),
 	})
 	require.NoError(t, err)
-	require.Equal(t, 3, summary.probes)
-	require.Len(t, calls, 3)
-	for _, call := range calls {
-		require.Equal(t, xdr.ScSymbol("decimals"), call.FunctionName)
-		require.Empty(t, call.Args)
+	require.Equal(t, 2, summary.selectedAccounts)
+	require.Equal(t, 6, summary.totalProbes)
+	require.Equal(t, 6, summary.probes)
+	require.Len(t, calls, 6)
+	require.Equal(t, []string{
+		accounts[0].Address(), accounts[0].Address(), accounts[0].Address(),
+		accounts[1].Address(), accounts[1].Address(), accounts[1].Address(),
+	}, txSources)
+	require.Equal(t, txSources, opSources)
+	for i, call := range calls {
+		src := accounts[i/3]
+		dst := accounts[1]
+		if src.Address() == dst.Address() {
+			dst = accounts[0]
+		}
+		require.Equal(t, xdr.ScSymbol("transfer"), call.FunctionName)
+		require.Len(t, call.Args, 3)
+		require.Equal(t, src.Address(), call.Args[0].Address.AccountId.Address())
+		require.Equal(t, dst.Address(), call.Args[1].Address.AccountId.Address())
+		amount, ok := call.Args[2].GetI128()
+		require.True(t, ok)
+		require.Equal(t, xdr.Uint64(sacTransferAmount), amount.Lo)
 	}
 }
 
@@ -176,6 +201,16 @@ func TestRestoreAccountLimitAppliesPerModeAccountSelection(t *testing.T) {
 		SoroswapPairContracts:   []string{mustContractID(t, 7), mustContractID(t, 8)},
 	}
 
+	sacSummary, err := restoreSACContracts(context.Background(), st, RestoreOptions{AccountLimit: 2, DryRun: true}, restoreSummary{
+		mode:      config.ModeSACTransfer,
+		dryRun:    true,
+		startedAt: time.Now(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, sacSummary.selectedAccounts)
+	require.Equal(t, 2*len(st.SACs), sacSummary.totalProbes)
+	require.Equal(t, sacSummary.totalProbes, sacSummary.probes)
+
 	ozSummary, err := restoreOZBalances(context.Background(), st, RestoreOptions{AccountLimit: 2, DryRun: true}, restoreSummary{
 		mode:      config.ModeOZTransfer,
 		dryRun:    true,
@@ -199,6 +234,80 @@ func TestRestoreAccountLimitAppliesPerModeAccountSelection(t *testing.T) {
 	for _, amount := range soroswapAmounts {
 		require.Equal(t, xdr.Uint64(1000), amount)
 	}
+}
+
+func TestRestoreArchivedStateRunsSoroswapBenchmarkFootprintValidation(t *testing.T) {
+	oldProbe := restoreInvokeContract
+	oldTokenBalance := restoreSoroswapTokenBalance
+	defer func() {
+		restoreInvokeContract = oldProbe
+		restoreSoroswapTokenBalance = oldTokenBalance
+	}()
+
+	balanceContractID := xdr.ContractId{9}
+	restoreProbeCalls := 0
+	validationProbeCalls := 0
+	restoreInvokeContract = func(
+		_ context.Context,
+		_ *state.State,
+		_ *keypair.Full,
+		_ string,
+		invokeArgs xdr.InvokeContractArgs,
+		_ int64,
+		options sharedsoroban.RestoreProbeOptions,
+	) (sharedsoroban.RestoreProbeResult, error) {
+		traderAddress := mustSwapTraderAddress(t, invokeArgs)
+		if options.DryRun {
+			validationProbeCalls++
+		} else {
+			restoreProbeCalls++
+		}
+		footprint := xdr.LedgerFootprint{ReadWrite: []xdr.LedgerKey{mustBalanceKey(t, balanceContractID, traderAddress)}}
+		return sharedsoroban.RestoreProbeResult{
+			HasSimulation: true,
+			Simulation:    sharedTestSimulatedInvocation(xdr.SorobanResources{Footprint: footprint}, 100),
+		}, nil
+	}
+	restoreSoroswapTokenBalance = func(context.Context, *state.State, string, string) (xdr.Int128Parts, error) {
+		return xdr.Int128Parts{Hi: 0, Lo: 1_000_000}, nil
+	}
+
+	issuer := mustRandomKP(t)
+	accounts := []*keypair.Full{mustRandomKP(t), mustRandomKP(t)}
+	st := &state.State{
+		FeePayerKP:        mustRandomKP(t),
+		NetworkPassphrase: network.TestNetworkPassphrase,
+		Assets: [3]txnbuild.CreditAsset{
+			{Code: "BLTA", Issuer: issuer.Address()},
+			{Code: "BLTB", Issuer: issuer.Address()},
+			{Code: "BLTC", Issuer: issuer.Address()},
+		},
+		AccountKPs:              accounts,
+		SACHolderKPs:            accounts,
+		SACs:                    [3]string{mustContractID(t, 1), mustContractID(t, 2), mustContractID(t, 3)},
+		SoroswapFactoryContract: mustContractID(t, 5),
+		SoroswapRouterContract:  mustContractID(t, 6),
+		SoroswapPairContracts:   []string{mustContractID(t, 7), mustContractID(t, 8)},
+	}
+
+	var buf bytes.Buffer
+	logger := log.New()
+	logger.SetLevel(log.InfoLevel)
+	logger.SetOutput(&buf)
+	logger.DisableColors()
+	logger.DisableTimestamp()
+
+	err := RestoreArchivedState(context.Background(), logger, st, RestoreOptions{
+		Mode:             string(config.ModeSoroswap),
+		AccountLimit:     2,
+		ProgressInterval: -1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2*len(sharedsoroswap.BenchmarkPairs)*2, restoreProbeCalls)
+	require.Equal(t, len(sharedsoroswap.BenchmarkPairs)*2+2*len(sharedsoroswap.BenchmarkPairs)*2, validationProbeCalls)
+	require.Contains(t, buf.String(), "soroswap benchmark footprint validation summary")
+	require.Contains(t, buf.String(), "benchmarkProbes=8")
+	require.Contains(t, buf.String(), "footprintMismatches=0")
 }
 
 func TestRestoreStopsAfterContextCancellation(t *testing.T) {
@@ -252,4 +361,14 @@ func mustContractID(t *testing.T, marker byte) string {
 	encoded, err := ledger.EncodeContractID(id)
 	require.NoError(t, err)
 	return encoded
+}
+
+func mustSwapTraderAddress(t *testing.T, invokeArgs xdr.InvokeContractArgs) string {
+	t.Helper()
+	require.Equal(t, xdr.ScSymbol("swap_exact_tokens_for_tokens"), invokeArgs.FunctionName)
+	require.Len(t, invokeArgs.Args, 5)
+	trader := invokeArgs.Args[3]
+	require.NotNil(t, trader.Address)
+	require.NotNil(t, trader.Address.AccountId)
+	return trader.Address.AccountId.Address()
 }

--- a/cmd/tx-load-test/benchmark/runner.go
+++ b/cmd/tx-load-test/benchmark/runner.go
@@ -17,9 +17,9 @@ import (
 // runVegetaAttack is the shared Vegeta harness used by all benchmark modes.
 // It constructs a RampToConstantPacer and drives the attack for cfg.Duration.
 //
-// After the attack finishes, a pool of poll worker goroutines drains the
-// accepted-transaction hashes by calling getTransaction until each reaches a
-// terminal state (SUCCESS or FAILED).  This gives a complete picture of
+// After the attack finishes, a fair poll scheduler drains accepted-transaction
+// hashes with bounded getTransaction attempts until each reaches terminal state
+// (SUCCESS or FAILED) or its poll deadline. This gives a complete picture of
 // on-chain outcomes, not just submission acceptance.
 func runVegetaAttack(
 	ctx context.Context,

--- a/cmd/tx-load-test/benchmark/runner_attack.go
+++ b/cmd/tx-load-test/benchmark/runner_attack.go
@@ -38,6 +38,12 @@ type pollItem struct {
 	rpcID              int64
 	submittedAt        time.Time
 	submitLatestLedger uint32
+	// submitLatestLedgerCloseTime is the unix-seconds close time of the
+	// latest ledger known to the RPC at the moment sendTransaction returned
+	// PENDING. The poll scheduler uses this to predict the next viable poll
+	// moment (close + indexing window) so the first attempt isn't wasted on
+	// the inter-close interval.
+	submitLatestLedgerCloseTime int64
 }
 
 type attackState struct {
@@ -99,10 +105,11 @@ func (s *attackState) handleSendTransactionEnvelope(envelope sendRespEnvelope, s
 	switch envelope.Result.Status {
 	case "PENDING", "DUPLICATE":
 		s.hashes <- pollItem{
-			hash:               envelope.Result.Hash,
-			rpcID:              envelope.ID,
-			submittedAt:        submittedAt,
-			submitLatestLedger: envelope.Result.LatestLedger,
+			hash:                        envelope.Result.Hash,
+			rpcID:                       envelope.ID,
+			submittedAt:                 submittedAt,
+			submitLatestLedger:          envelope.Result.LatestLedger,
+			submitLatestLedgerCloseTime: envelope.Result.LatestLedgerCloseTime,
 		}
 		atomic.AddUint64(&s.queued, 1)
 		return true

--- a/cmd/tx-load-test/benchmark/runner_attack.go
+++ b/cmd/tx-load-test/benchmark/runner_attack.go
@@ -210,7 +210,15 @@ func processAttackResult(res *vegeta.Result, metrics *vegeta.Metrics, logger *lo
 			ResponseBody:      string(res.Body),
 		})
 	}
-	if !state.handleSendTransactionEnvelope(envelope, res.Timestamp, accounts) {
+	// Use the time the PENDING response was received (hit start + request
+	// latency), NOT res.Timestamp (the vegeta hit start). When the account
+	// pool is contended the targeter blocks in Acquire before the tx is ever
+	// sent, so res.Timestamp can predate the actual submit by tens of seconds.
+	// Anchoring the poll deadline (and e2e latency) to res.Timestamp would
+	// charge that Acquire wait against the poll budget, pre-expiring the
+	// deadline so the tx is abandoned after a single NOT_FOUND poll.
+	respReceivedAt := res.Timestamp.Add(res.Latency)
+	if !state.handleSendTransactionEnvelope(envelope, respReceivedAt, accounts) {
 		atomic.AddUint64(&state.httpErr, 1)
 		logger.Debugf("sendTransaction: unknown status %q", envelope.Result.Status)
 	}

--- a/cmd/tx-load-test/benchmark/runner_polling.go
+++ b/cmd/tx-load-test/benchmark/runner_polling.go
@@ -1,7 +1,9 @@
 package benchmark
 
 import (
+	"container/heap"
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,37 +30,384 @@ func pollWorkerCount(targetRPS int) int {
 // timing out first.
 const pollTimeout = 25 * time.Second
 
+const (
+	pollBatchSize      = 25
+	pollAttemptTimeout = 5 * time.Second
+	pollInitialBackoff = 500 * time.Millisecond
+	pollMaxBackoff     = 3500 * time.Millisecond
+)
+
 type pollTransactionResult struct {
 	response                 protocol.GetTransactionResponse
 	lastObservedLatestLedger uint32
 }
 
+type pollSchedulerOptions struct {
+	maxConcurrency int
+	batchSize      int
+	timeout        time.Duration
+	attemptTimeout time.Duration
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	jitter         bool
+}
+
+func defaultPollSchedulerOptions(maxConcurrency int) pollSchedulerOptions {
+	return pollSchedulerOptions{
+		maxConcurrency: maxConcurrency,
+		batchSize:      pollBatchSize,
+		timeout:        pollTimeout,
+		attemptTimeout: pollAttemptTimeout,
+		initialBackoff: pollInitialBackoff,
+		maxBackoff:     pollMaxBackoff,
+		jitter:         true,
+	}.normalized()
+}
+
+func (o pollSchedulerOptions) normalized() pollSchedulerOptions {
+	if o.maxConcurrency <= 0 {
+		o.maxConcurrency = 1
+	}
+	if o.batchSize <= 0 {
+		o.batchSize = 1
+	}
+	if o.timeout <= 0 {
+		o.timeout = pollTimeout
+	}
+	if o.attemptTimeout <= 0 {
+		o.attemptTimeout = pollAttemptTimeout
+	}
+	if o.initialBackoff <= 0 {
+		o.initialBackoff = pollInitialBackoff
+	}
+	if o.maxBackoff < o.initialBackoff {
+		o.maxBackoff = o.initialBackoff
+	}
+	return o
+}
+
+type scheduledPollItem struct {
+	item                     pollItem
+	submitIndex              uint64
+	attempt                  int
+	nextPollAt               time.Time
+	pollDeadline             time.Time
+	lastObservedLatestLedger uint32
+}
+
+type pollScheduleHeap []*scheduledPollItem
+
+func (h pollScheduleHeap) Len() int { return len(h) }
+
+func (h pollScheduleHeap) Less(i, j int) bool {
+	if h[i].nextPollAt.Equal(h[j].nextPollAt) {
+		return h[i].submitIndex < h[j].submitIndex
+	}
+	return h[i].nextPollAt.Before(h[j].nextPollAt)
+}
+
+func (h pollScheduleHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
+
+func (h *pollScheduleHeap) Push(x any) {
+	*h = append(*h, x.(*scheduledPollItem))
+}
+
+func (h *pollScheduleHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+type pollBatchResult struct {
+	items   []*scheduledPollItem
+	results []transactionPollAttemptResult
+	err     error
+}
+
 func startPollWorkersWithTrace(ctx context.Context, logger *log.Entry, cfg config.Config, rpc *rpcclient.Client, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder) (int, *sync.WaitGroup) {
 	numPollWorkers := pollWorkerCount(cfg.TargetRPS)
 	logger.Infof("starting %d poll workers", numPollWorkers)
-	var pollWg sync.WaitGroup
-	for range numPollWorkers {
-		pollWg.Go(func() {
-			pollTransactions(ctx, logger, rpc, state, accounts, workload, recorder)
-		})
-	}
-	return numPollWorkers, &pollWg
+	return startPollSchedulerWithClient(ctx, logger, newSDKTransactionPollClient(rpc), state, accounts, workload, recorder, defaultPollSchedulerOptions(numPollWorkers))
 }
 
-func pollTransactions(ctx context.Context, logger *log.Entry, rpc *rpcclient.Client, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder) {
-	for item := range state.hashes {
-		pollCtx, pollCancel := context.WithTimeout(ctx, pollTimeout)
-		result, err := pollTransactionWithTrace(pollCtx, rpc, item.hash, workload, recorder)
-		pollCancel()
-		if err != nil {
-			state.ledgerStats.observeTimeout(item.submitLatestLedger, result.lastObservedLatestLedger)
-			atomic.AddUint64(&state.pollErr, 1)
-			logger.WithError(err).Debugf("poll failed: hash=%s", item.hash)
-			atomic.AddUint64(&state.ambiguous, 1)
-			releaseAmbiguous(accounts, item.rpcID)
+func startPollSchedulerWithClient(ctx context.Context, logger *log.Entry, client transactionPollClient, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions) (int, *sync.WaitGroup) {
+	options = options.normalized()
+	var pollWg sync.WaitGroup
+	pollWg.Go(func() {
+		runPollScheduler(ctx, logger, client, state, accounts, workload, recorder, options)
+	})
+	return options.maxConcurrency, &pollWg
+}
+
+func runPollScheduler(ctx context.Context, logger *log.Entry, client transactionPollClient, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions) {
+	var queue pollScheduleHeap
+	heap.Init(&queue)
+	results := make(chan pollBatchResult, options.maxConcurrency)
+	hashes := state.hashes
+	inputOpen := true
+	var submitIndex uint64
+	inFlight := 0
+	ctxDone := ctx.Done()
+	ctxCanceled := false
+
+	for {
+		if !inputOpen && queue.Len() == 0 && inFlight == 0 {
+			return
+		}
+
+		if !ctxCanceled {
+			progressed := dispatchDuePollBatches(ctx, logger, client, &queue, results, &inFlight, state, accounts, workload, recorder, options)
+			if progressed {
+				continue
+			}
+		}
+
+		var dueTimer *time.Timer
+		var due <-chan time.Time
+		if !ctxCanceled && inFlight < options.maxConcurrency && queue.Len() > 0 {
+			delay := time.Until(queue[0].nextPollAt)
+			if delay < 0 {
+				delay = 0
+			}
+			dueTimer = time.NewTimer(delay)
+			due = dueTimer.C
+		}
+
+		select {
+		case item, ok := <-hashes:
+			stopPollTimer(dueTimer)
+			if !ok {
+				inputOpen = false
+				hashes = nil
+				continue
+			}
+			scheduled := newScheduledPollItem(item, submitIndex, time.Now(), options.timeout)
+			submitIndex++
+			if ctxCanceled {
+				timeoutScheduledPollItem(logger, state, scheduled, accounts, ctx.Err())
+				continue
+			}
+			heap.Push(&queue, scheduled)
+		case result := <-results:
+			stopPollTimer(dueTimer)
+			inFlight--
+			handlePollBatchResult(time.Now(), logger, state, &queue, result, accounts, workload, recorder, options, ctxCanceled)
+		case <-due:
+		case <-ctxDone:
+			stopPollTimer(dueTimer)
+			ctxCanceled = true
+			ctxDone = nil
+			timeoutPendingPollItems(logger, state, &queue, accounts, ctx.Err())
+		}
+	}
+}
+
+func newScheduledPollItem(item pollItem, submitIndex uint64, now time.Time, timeout time.Duration) *scheduledPollItem {
+	if item.submittedAt.IsZero() {
+		item.submittedAt = now
+	}
+	return &scheduledPollItem{
+		item:         item,
+		submitIndex:  submitIndex,
+		nextPollAt:   now,
+		pollDeadline: item.submittedAt.Add(timeout),
+	}
+}
+
+func dispatchDuePollBatches(ctx context.Context, logger *log.Entry, client transactionPollClient, queue *pollScheduleHeap, results chan<- pollBatchResult, inFlight *int, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions) bool {
+	if *inFlight >= options.maxConcurrency || queue.Len() == 0 {
+		return false
+	}
+
+	now := time.Now()
+	if queue.Len() > 0 && queue.peek().nextPollAt.After(now) {
+		return false
+	}
+
+	batch := make([]*scheduledPollItem, 0, options.batchSize)
+	progressed := false
+	for len(batch) < options.batchSize && queue.Len() > 0 {
+		scheduled := queue.peek()
+		if scheduled.nextPollAt.After(now) {
+			break
+		}
+		scheduled = heap.Pop(queue).(*scheduledPollItem)
+		progressed = true
+		if scheduled.attempt > 0 && !now.Before(scheduled.pollDeadline) {
+			timeoutScheduledPollItem(logger, state, scheduled, accounts, fmt.Errorf("poll deadline exceeded"))
 			continue
 		}
-		handlePollResponse(logger, state, item, &result.response, accounts)
+		scheduled.attempt++
+		recordPollRequestTrace(workload, scheduled.item.hash, scheduled.item.rpcID, scheduled.attempt, recorder)
+		batch = append(batch, scheduled)
+	}
+
+	if len(batch) == 0 {
+		return progressed
+	}
+
+	*inFlight++
+	go runPollBatch(ctx, client, batch, results, options)
+	return true
+}
+
+func (h pollScheduleHeap) peek() *scheduledPollItem {
+	return h[0]
+}
+
+func runPollBatch(ctx context.Context, client transactionPollClient, batch []*scheduledPollItem, results chan<- pollBatchResult, options pollSchedulerOptions) {
+	requests := make([]transactionPollRequest, len(batch))
+	for i, item := range batch {
+		requests[i] = transactionPollRequest{ID: pollRequestID(item), Hash: item.item.hash}
+	}
+
+	if client == nil {
+		results <- pollBatchResult{items: batch, err: fmt.Errorf("missing transaction poll client")}
+		return
+	}
+
+	attemptCtx := ctx
+	var cancel context.CancelFunc
+	if options.attemptTimeout > 0 {
+		attemptCtx, cancel = context.WithTimeout(ctx, options.attemptTimeout)
+	}
+	responses, err := client.GetTransactions(attemptCtx, requests)
+	if cancel != nil {
+		cancel()
+	}
+	results <- pollBatchResult{items: batch, results: responses, err: err}
+}
+
+func pollRequestID(item *scheduledPollItem) int64 {
+	return int64(item.submitIndex + 1)
+}
+
+func handlePollBatchResult(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, batch pollBatchResult, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions, ctxCanceled bool) {
+	if batch.err != nil {
+		for _, item := range batch.items {
+			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, batch.err, recorder)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, batch.err, options, ctxCanceled)
+		}
+		return
+	}
+
+	resultsByID := make(map[int64]transactionPollAttemptResult, len(batch.results))
+	for _, result := range batch.results {
+		resultsByID[result.ID] = result
+	}
+
+	for _, item := range batch.items {
+		result, ok := resultsByID[pollRequestID(item)]
+		if !ok {
+			err := fmt.Errorf("missing poll response for hash %s", item.item.hash)
+			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, err, recorder)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+			continue
+		}
+		if result.Hash != "" && result.Hash != item.item.hash {
+			err := fmt.Errorf("poll response hash mismatch: request=%s response=%s", item.item.hash, result.Hash)
+			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, err, recorder)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+			continue
+		}
+		if result.Err != nil {
+			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, result.Err, recorder)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, result.Err, options, ctxCanceled)
+			continue
+		}
+
+		resp := result.Response
+		recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, &resp, nil, recorder)
+		handlePollAttemptResponse(now, logger, state, queue, item, &resp, accounts, options, ctxCanceled)
+	}
+}
+
+func handlePollAttemptResponse(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, resp *protocol.GetTransactionResponse, accounts accountLeaseManager, options pollSchedulerOptions, ctxCanceled bool) {
+	if resp.LatestLedger > 0 {
+		item.lastObservedLatestLedger = resp.LatestLedger
+	}
+
+	switch resp.Status {
+	case protocol.TransactionStatusSuccess, protocol.TransactionStatusFailed:
+		handlePollResponse(logger, state, item.item, resp, accounts)
+	case "":
+		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, fmt.Errorf("empty transaction status"), options, ctxCanceled)
+	default:
+		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, nil, options, ctxCanceled)
+	}
+}
+
+func handlePollAttemptError(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, err error, options pollSchedulerOptions, ctxCanceled bool) {
+	requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+}
+
+func requeueOrTimeoutPollItem(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, err error, options pollSchedulerOptions, ctxCanceled bool) {
+	if ctxCanceled || !now.Before(item.pollDeadline) {
+		if err == nil {
+			err = fmt.Errorf("poll deadline exceeded")
+		}
+		timeoutScheduledPollItem(logger, state, item, accounts, err)
+		return
+	}
+	item.nextPollAt = now.Add(pollBackoff(item, options))
+	heap.Push(queue, item)
+}
+
+func pollBackoff(item *scheduledPollItem, options pollSchedulerOptions) time.Duration {
+	backoff := options.initialBackoff
+	for range max(item.attempt-1, 0) {
+		backoff *= 2
+		if backoff >= options.maxBackoff {
+			backoff = options.maxBackoff
+			break
+		}
+	}
+	if !options.jitter || backoff <= 0 {
+		return backoff
+	}
+	jitterWindow := int64(min(backoff/10, 250*time.Millisecond))
+	if jitterWindow <= 0 {
+		return backoff
+	}
+	seed := item.submitIndex*1103515245 + uint64(item.attempt)*12345
+	jitter := time.Duration(int64(seed%uint64(jitterWindow*2+1)) - jitterWindow)
+	backoff += jitter
+	if backoff > options.maxBackoff {
+		return options.maxBackoff
+	}
+	if backoff < 0 {
+		return 0
+	}
+	return backoff
+}
+
+func timeoutPendingPollItems(logger *log.Entry, state *attackState, queue *pollScheduleHeap, accounts accountLeaseManager, err error) {
+	for queue.Len() > 0 {
+		timeoutScheduledPollItem(logger, state, heap.Pop(queue).(*scheduledPollItem), accounts, err)
+	}
+}
+
+func timeoutScheduledPollItem(logger *log.Entry, state *attackState, item *scheduledPollItem, accounts accountLeaseManager, err error) {
+	state.ledgerStats.observeTimeout(item.item.submitLatestLedger, item.lastObservedLatestLedger)
+	atomic.AddUint64(&state.pollErr, 1)
+	if logger != nil {
+		logger.WithError(err).Debugf("poll failed: hash=%s", item.item.hash)
+	}
+	atomic.AddUint64(&state.ambiguous, 1)
+	releaseAmbiguous(accounts, item.item.rpcID)
+}
+
+func stopPollTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
 	}
 }
 

--- a/cmd/tx-load-test/benchmark/runner_polling.go
+++ b/cmd/tx-load-test/benchmark/runner_polling.go
@@ -26,7 +26,7 @@ func pollWorkerCount(targetRPS int) int {
 // terminal state. It intentionally outlives the benchmark transaction expiry
 // so the poller can observe txTooLate-style terminal failures instead of
 // timing out first.
-const pollTimeout = 35 * time.Second
+const pollTimeout = 25 * time.Second
 
 type pollTransactionResult struct {
 	response                 protocol.GetTransactionResponse

--- a/cmd/tx-load-test/benchmark/runner_polling.go
+++ b/cmd/tx-load-test/benchmark/runner_polling.go
@@ -37,6 +37,27 @@ const (
 	pollMaxBackoff     = 3500 * time.Millisecond
 )
 
+const (
+	// estimatedLedgerCloseInterval is the assumed wall-clock interval between
+	// ledger closes. Used to predict when the next close after a submit will
+	// happen so the first poll attempt lands inside the index window rather
+	// than racing it. Mirrors state.BenchmarkLedgerCloseSeconds; not imported
+	// to keep this package self-contained, but the two must agree.
+	estimatedLedgerCloseInterval = 5 * time.Second
+	// estimatedRPCIndexingLag is the typical delay between a ledger closing on
+	// core and stellar-rpc surfacing a getTransaction result for txs in that
+	// ledger. Tuned for a stellar-rpc running on the same host as the bench
+	// (low millisecond network overhead); raise for shared/remote RPC nodes
+	// where indexing typically settles around 1.5 s.
+	estimatedRPCIndexingLag = 1 * time.Second
+	// minFirstPollDelay is the floor for the first poll attempt when we lack
+	// a useful close-time prediction (legacy poll items, oddly-shaped PENDING
+	// responses, or a submit that landed just before a close). Without this
+	// floor we'd issue the first poll within milliseconds of submit and waste
+	// a guaranteed-NOT_FOUND RPC round trip while the ledger hasn't closed.
+	minFirstPollDelay = 2 * time.Second
+)
+
 type pollTransactionResult struct {
 	response                 protocol.GetTransactionResponse
 	lastObservedLatestLedger uint32
@@ -49,6 +70,10 @@ type pollSchedulerOptions struct {
 	attemptTimeout time.Duration
 	initialBackoff time.Duration
 	maxBackoff     time.Duration
+	// firstPollDelay is the floor for the first poll attempt when no
+	// LatestLedgerCloseTime hint is available. Production uses
+	// minFirstPollDelay; tests can leave it zero for immediate-poll behavior.
+	firstPollDelay time.Duration
 	jitter         bool
 }
 
@@ -60,6 +85,7 @@ func defaultPollSchedulerOptions(maxConcurrency int) pollSchedulerOptions {
 		attemptTimeout: pollAttemptTimeout,
 		initialBackoff: pollInitialBackoff,
 		maxBackoff:     pollMaxBackoff,
+		firstPollDelay: minFirstPollDelay,
 		jitter:         true,
 	}.normalized()
 }
@@ -82,6 +108,9 @@ func (o pollSchedulerOptions) normalized() pollSchedulerOptions {
 	}
 	if o.maxBackoff < o.initialBackoff {
 		o.maxBackoff = o.initialBackoff
+	}
+	if o.firstPollDelay < 0 {
+		o.firstPollDelay = 0
 	}
 	return o
 }
@@ -183,7 +212,7 @@ func runPollScheduler(ctx context.Context, logger *log.Entry, client transaction
 				hashes = nil
 				continue
 			}
-			scheduled := newScheduledPollItem(item, submitIndex, time.Now(), options.timeout)
+			scheduled := newScheduledPollItem(item, submitIndex, time.Now(), options)
 			submitIndex++
 			if ctxCanceled {
 				timeoutScheduledPollItem(logger, state, scheduled, accounts, ctx.Err())
@@ -204,16 +233,39 @@ func runPollScheduler(ctx context.Context, logger *log.Entry, client transaction
 	}
 }
 
-func newScheduledPollItem(item pollItem, submitIndex uint64, now time.Time, timeout time.Duration) *scheduledPollItem {
+func newScheduledPollItem(item pollItem, submitIndex uint64, now time.Time, options pollSchedulerOptions) *scheduledPollItem {
 	if item.submittedAt.IsZero() {
 		item.submittedAt = now
 	}
 	return &scheduledPollItem{
 		item:         item,
 		submitIndex:  submitIndex,
-		nextPollAt:   now,
-		pollDeadline: item.submittedAt.Add(timeout),
+		nextPollAt:   firstPollAt(item, now, options.firstPollDelay),
+		pollDeadline: item.submittedAt.Add(options.timeout),
 	}
+}
+
+// firstPollAt returns when the first poll attempt for item should fire. It
+// targets the moment the next ledger close + RPC indexing window opens --
+// the earliest wall-clock instant getTransaction can return a terminal
+// status. The submitLatestLedgerCloseTime hint from sendTransaction tells us
+// when the previous close happened; the next close is one
+// estimatedLedgerCloseInterval later, plus an estimatedRPCIndexingLag
+// cushion. When that prediction is in the past (submit landed just before
+// the next close fired, or no hint was provided) we fall back to a floor of
+// now + minDelay so we still skip the guaranteed-NOT_FOUND polls.
+func firstPollAt(item pollItem, now time.Time, minDelay time.Duration) time.Time {
+	floor := now.Add(minDelay)
+	if item.submitLatestLedgerCloseTime <= 0 {
+		return floor
+	}
+	predicted := time.Unix(item.submitLatestLedgerCloseTime, 0).
+		Add(estimatedLedgerCloseInterval).
+		Add(estimatedRPCIndexingLag)
+	if predicted.Before(floor) {
+		return floor
+	}
+	return predicted
 }
 
 func dispatchDuePollBatches(ctx context.Context, logger *log.Entry, client transactionPollClient, queue *pollScheduleHeap, results chan<- pollBatchResult, inFlight *int, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions) bool {
@@ -356,13 +408,15 @@ func requeueOrTimeoutPollItem(now time.Time, logger *log.Entry, state *attackSta
 }
 
 func pollBackoff(item *scheduledPollItem, options pollSchedulerOptions) time.Duration {
-	backoff := options.initialBackoff
-	for range max(item.attempt-1, 0) {
-		backoff *= 2
-		if backoff >= options.maxBackoff {
-			backoff = options.maxBackoff
-			break
-		}
+	// Linear arithmetic-step backoff: attempt N waits N * initialBackoff,
+	// capped at maxBackoff. With the prediction-based first poll already
+	// landing inside the ledger close + index window, exponential growth is
+	// unnecessary -- a linear step lets subsequent attempts spread out
+	// gradually as the tx ages without slipping a full ledger close behind.
+	attempts := max(item.attempt, 1)
+	backoff := time.Duration(attempts) * options.initialBackoff
+	if backoff > options.maxBackoff {
+		backoff = options.maxBackoff
 	}
 	if !options.jitter || backoff <= 0 {
 		return backoff

--- a/cmd/tx-load-test/benchmark/runner_polling.go
+++ b/cmd/tx-load-test/benchmark/runner_polling.go
@@ -31,8 +31,13 @@ func pollWorkerCount(targetRPS int) int {
 const pollTimeout = 25 * time.Second
 
 const (
-	pollBatchSize      = 25
-	pollAttemptTimeout = 5 * time.Second
+	pollBatchSize = 25
+	// pollAttemptTimeout bounds a single batch's getTransaction round trip.
+	// Kept just above the observed median getTransaction latency under load so
+	// slow-but-valid calls complete instead of being cancelled mid-flight and
+	// retried (which wastes the call and learns nothing). Still well under
+	// pollTimeout so an item can make several attempts before its deadline.
+	pollAttemptTimeout = 6 * time.Second
 	pollInitialBackoff = 500 * time.Millisecond
 	pollMaxBackoff     = 3500 * time.Millisecond
 )
@@ -58,6 +63,70 @@ const (
 	minFirstPollDelay = 2 * time.Second
 )
 
+const (
+	// ledgerGateRecheckFloor bounds how soon a gated (deferred) item can be
+	// reconsidered. A re-poll can only yield a new answer once a new ledger has
+	// closed, so deferred items are scheduled toward the next expected close;
+	// this floor keeps a stale/absent close-time hint from spinning the queue.
+	ledgerGateRecheckFloor = 500 * time.Millisecond
+	// ledgerClockStaleness is how long the shared ledger clock may go without an
+	// update before the fallback ticker spends a getLatestLedger call. In steady
+	// state getTransaction responses refresh the clock well within this window,
+	// so the (heavyweight) ticker call is skipped; it only fires during the
+	// drain tail when poll traffic has dried up.
+	ledgerClockStaleness = estimatedLedgerCloseInterval + 2*time.Second
+	// ledgerTickerLateRetry is the short wait the ticker uses when a close ran
+	// late (the sequence did not advance), so a slightly-late close is caught
+	// promptly instead of after another full interval.
+	ledgerTickerLateRetry = 1 * time.Second
+)
+
+// ledgerClock holds the highest network ledger sequence (and its close time)
+// observed from any source -- every getTransaction response feeds it for free,
+// and the fallback ticker tops it up during the drain tail. The poll scheduler
+// reads it to gate re-polls: a transaction's terminal status can only change at
+// a ledger close, so an item is only worth re-polling once the clock has
+// advanced past the ledger that item last observed. Concurrent writers (the
+// scheduler goroutine processing responses, and the ticker goroutine) update it
+// via monotonic CAS; reads are lock-free.
+type ledgerClock struct {
+	sequence   atomic.Uint32
+	closeUnix  atomic.Int64
+	lastUpdate atomic.Int64 // unix nanos of the most recent advancing update
+}
+
+// observe records a (sequence, closeUnix) sample, keeping the max sequence. now
+// is passed in so callers can use a single clock reading; it stamps lastUpdate
+// only when the sequence actually advances.
+func (c *ledgerClock) observe(sequence uint32, closeUnix int64, now time.Time) {
+	for {
+		cur := c.sequence.Load()
+		if sequence <= cur {
+			return
+		}
+		if c.sequence.CompareAndSwap(cur, sequence) {
+			if closeUnix > 0 {
+				c.closeUnix.Store(closeUnix)
+			}
+			c.lastUpdate.Store(now.UnixNano())
+			return
+		}
+	}
+}
+
+func (c *ledgerClock) latestSequence() uint32 { return c.sequence.Load() }
+func (c *ledgerClock) latestCloseUnix() int64 { return c.closeUnix.Load() }
+
+// fresh reports whether the clock was advanced within ledgerClockStaleness of
+// now -- i.e. whether poll responses are keeping it current without help.
+func (c *ledgerClock) fresh(now time.Time) bool {
+	last := c.lastUpdate.Load()
+	if last == 0 {
+		return false
+	}
+	return now.Sub(time.Unix(0, last)) < ledgerClockStaleness
+}
+
 type pollTransactionResult struct {
 	response                 protocol.GetTransactionResponse
 	lastObservedLatestLedger uint32
@@ -74,7 +143,12 @@ type pollSchedulerOptions struct {
 	// LatestLedgerCloseTime hint is available. Production uses
 	// minFirstPollDelay; tests can leave it zero for immediate-poll behavior.
 	firstPollDelay time.Duration
-	jitter         bool
+	// ledgerGated enables the ledger-advance re-poll gate: an item is only
+	// re-polled once the shared ledger clock has advanced past the ledger that
+	// item last observed. Production enables it; tests leave it off (zero) to
+	// keep the unconditional time-based behavior unless explicitly exercised.
+	ledgerGated bool
+	jitter      bool
 }
 
 func defaultPollSchedulerOptions(maxConcurrency int) pollSchedulerOptions {
@@ -86,6 +160,7 @@ func defaultPollSchedulerOptions(maxConcurrency int) pollSchedulerOptions {
 		initialBackoff: pollInitialBackoff,
 		maxBackoff:     pollMaxBackoff,
 		firstPollDelay: minFirstPollDelay,
+		ledgerGated:    true,
 		jitter:         true,
 	}.normalized()
 }
@@ -122,6 +197,11 @@ type scheduledPollItem struct {
 	nextPollAt               time.Time
 	pollDeadline             time.Time
 	lastObservedLatestLedger uint32
+	// lastObservedCloseUnix is the close time (unix seconds) of the latest
+	// ledger this item's most recent response reported. Used to schedule the
+	// next re-poll toward the following expected close so the item sleeps
+	// through the inter-close interval instead of waking to be gate-deferred.
+	lastObservedCloseUnix int64
 }
 
 type pollScheduleHeap []*scheduledPollItem
@@ -181,13 +261,26 @@ func runPollScheduler(ctx context.Context, logger *log.Entry, client transaction
 	ctxDone := ctx.Done()
 	ctxCanceled := false
 
+	clock := &ledgerClock{}
+	// Start the fallback latest-ledger ticker only when gating is on and the
+	// client can report the latest ledger. It stays dormant while poll
+	// responses keep the clock fresh and only spends a getLatestLedger call
+	// during the drain tail. Stop it when the scheduler returns.
+	if options.ledgerGated {
+		if observer, ok := client.(latestLedgerObserver); ok {
+			tickerStop := make(chan struct{})
+			defer close(tickerStop)
+			go runLatestLedgerTicker(ctx, tickerStop, observer, clock)
+		}
+	}
+
 	for {
 		if !inputOpen && queue.Len() == 0 && inFlight == 0 {
 			return
 		}
 
 		if !ctxCanceled {
-			progressed := dispatchDuePollBatches(ctx, logger, client, &queue, results, &inFlight, state, accounts, workload, recorder, options)
+			progressed := dispatchDuePollBatches(ctx, logger, client, &queue, results, &inFlight, state, accounts, workload, recorder, options, clock)
 			if progressed {
 				continue
 			}
@@ -222,7 +315,7 @@ func runPollScheduler(ctx context.Context, logger *log.Entry, client transaction
 		case result := <-results:
 			stopPollTimer(dueTimer)
 			inFlight--
-			handlePollBatchResult(time.Now(), logger, state, &queue, result, accounts, workload, recorder, options, ctxCanceled)
+			handlePollBatchResult(time.Now(), logger, state, &queue, result, accounts, workload, recorder, options, clock, ctxCanceled)
 		case <-due:
 		case <-ctxDone:
 			stopPollTimer(dueTimer)
@@ -268,7 +361,41 @@ func firstPollAt(item pollItem, now time.Time, minDelay time.Duration) time.Time
 	return predicted
 }
 
-func dispatchDuePollBatches(ctx context.Context, logger *log.Entry, client transactionPollClient, queue *pollScheduleHeap, results chan<- pollBatchResult, inFlight *int, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions) bool {
+// ledgerGateBlocks reports whether a re-poll of item should be deferred because
+// no new ledger has closed since it was last observed. It blocks only when both
+// the item and the clock have a known ledger and the clock has not advanced past
+// the item's last-observed ledger. When the clock is unknown (no observation
+// yet) or the item has no observed ledger (e.g. its last attempt errored), it
+// does not block -- falling back to time-based scheduling.
+func ledgerGateBlocks(item *scheduledPollItem, clock *ledgerClock) bool {
+	if clock == nil {
+		return false
+	}
+	latest := clock.latestSequence()
+	if latest == 0 || item.lastObservedLatestLedger == 0 {
+		return false
+	}
+	return latest <= item.lastObservedLatestLedger
+}
+
+// nextCloseProjection returns when a deferred item should next be considered:
+// the close after the one it last observed, plus the indexing cushion, floored
+// so a missing or stale close-time hint cannot spin the queue.
+func nextCloseProjection(now time.Time, lastObservedCloseUnix int64) time.Time {
+	floor := now.Add(ledgerGateRecheckFloor)
+	if lastObservedCloseUnix <= 0 {
+		return floor
+	}
+	projected := time.Unix(lastObservedCloseUnix, 0).
+		Add(estimatedLedgerCloseInterval).
+		Add(estimatedRPCIndexingLag)
+	if projected.Before(floor) {
+		return floor
+	}
+	return projected
+}
+
+func dispatchDuePollBatches(ctx context.Context, logger *log.Entry, client transactionPollClient, queue *pollScheduleHeap, results chan<- pollBatchResult, inFlight *int, state *attackState, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions, clock *ledgerClock) bool {
 	if *inFlight >= options.maxConcurrency || queue.Len() == 0 {
 		return false
 	}
@@ -289,6 +416,16 @@ func dispatchDuePollBatches(ctx context.Context, logger *log.Entry, client trans
 		progressed = true
 		if scheduled.attempt > 0 && !now.Before(scheduled.pollDeadline) {
 			timeoutScheduledPollItem(logger, state, scheduled, accounts, fmt.Errorf("poll deadline exceeded"))
+			continue
+		}
+		// Ledger-advance gate: a re-poll can only return a new answer once a new
+		// ledger has closed. If the shared clock has not advanced past the ledger
+		// this item last observed, defer it toward the next expected close
+		// instead of spending a (whole-ledger-decoding) getTransaction call. The
+		// first attempt is never gated -- it is timed by firstPollAt.
+		if options.ledgerGated && scheduled.attempt > 0 && ledgerGateBlocks(scheduled, clock) {
+			scheduled.nextPollAt = nextCloseProjection(now, scheduled.lastObservedCloseUnix)
+			heap.Push(queue, scheduled)
 			continue
 		}
 		scheduled.attempt++
@@ -336,11 +473,11 @@ func pollRequestID(item *scheduledPollItem) int64 {
 	return int64(item.submitIndex + 1)
 }
 
-func handlePollBatchResult(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, batch pollBatchResult, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions, ctxCanceled bool) {
+func handlePollBatchResult(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, batch pollBatchResult, accounts accountLeaseManager, workload string, recorder *benchmarkTraceRecorder, options pollSchedulerOptions, clock *ledgerClock, ctxCanceled bool) {
 	if batch.err != nil {
 		for _, item := range batch.items {
 			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, batch.err, recorder)
-			handlePollAttemptError(now, logger, state, queue, item, accounts, batch.err, options, ctxCanceled)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, options, clock, batch.err, ctxCanceled)
 		}
 		return
 	}
@@ -355,47 +492,53 @@ func handlePollBatchResult(now time.Time, logger *log.Entry, state *attackState,
 		if !ok {
 			err := fmt.Errorf("missing poll response for hash %s", item.item.hash)
 			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, err, recorder)
-			handlePollAttemptError(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, options, clock, err, ctxCanceled)
 			continue
 		}
 		if result.Hash != "" && result.Hash != item.item.hash {
 			err := fmt.Errorf("poll response hash mismatch: request=%s response=%s", item.item.hash, result.Hash)
 			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, err, recorder)
-			handlePollAttemptError(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, options, clock, err, ctxCanceled)
 			continue
 		}
 		if result.Err != nil {
 			recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, nil, result.Err, recorder)
-			handlePollAttemptError(now, logger, state, queue, item, accounts, result.Err, options, ctxCanceled)
+			handlePollAttemptError(now, logger, state, queue, item, accounts, options, clock, result.Err, ctxCanceled)
 			continue
 		}
 
 		resp := result.Response
 		recordPollResponseTrace(workload, item.item.hash, item.item.rpcID, item.attempt, &resp, nil, recorder)
-		handlePollAttemptResponse(now, logger, state, queue, item, &resp, accounts, options, ctxCanceled)
+		handlePollAttemptResponse(now, logger, state, queue, item, &resp, accounts, options, clock, ctxCanceled)
 	}
 }
 
-func handlePollAttemptResponse(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, resp *protocol.GetTransactionResponse, accounts accountLeaseManager, options pollSchedulerOptions, ctxCanceled bool) {
+func handlePollAttemptResponse(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, resp *protocol.GetTransactionResponse, accounts accountLeaseManager, options pollSchedulerOptions, clock *ledgerClock, ctxCanceled bool) {
 	if resp.LatestLedger > 0 {
 		item.lastObservedLatestLedger = resp.LatestLedger
+		if resp.LatestLedgerCloseTime > 0 {
+			item.lastObservedCloseUnix = resp.LatestLedgerCloseTime
+		}
+		// Feed the shared clock for free from every response; this is what keeps
+		// the ledger-advance gate current in steady state without the ticker.
+		clock.observe(resp.LatestLedger, resp.LatestLedgerCloseTime, now)
 	}
 
 	switch resp.Status {
 	case protocol.TransactionStatusSuccess, protocol.TransactionStatusFailed:
 		handlePollResponse(logger, state, item.item, resp, accounts)
 	case "":
-		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, fmt.Errorf("empty transaction status"), options, ctxCanceled)
+		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, options, clock, fmt.Errorf("empty transaction status"), ctxCanceled)
 	default:
-		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, nil, options, ctxCanceled)
+		requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, options, clock, nil, ctxCanceled)
 	}
 }
 
-func handlePollAttemptError(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, err error, options pollSchedulerOptions, ctxCanceled bool) {
-	requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, err, options, ctxCanceled)
+func handlePollAttemptError(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, options pollSchedulerOptions, clock *ledgerClock, err error, ctxCanceled bool) {
+	requeueOrTimeoutPollItem(now, logger, state, queue, item, accounts, options, clock, err, ctxCanceled)
 }
 
-func requeueOrTimeoutPollItem(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, err error, options pollSchedulerOptions, ctxCanceled bool) {
+func requeueOrTimeoutPollItem(now time.Time, logger *log.Entry, state *attackState, queue *pollScheduleHeap, item *scheduledPollItem, accounts accountLeaseManager, options pollSchedulerOptions, clock *ledgerClock, err error, ctxCanceled bool) {
 	if ctxCanceled || !now.Before(item.pollDeadline) {
 		if err == nil {
 			err = fmt.Errorf("poll deadline exceeded")
@@ -403,7 +546,17 @@ func requeueOrTimeoutPollItem(now time.Time, logger *log.Entry, state *attackSta
 		timeoutScheduledPollItem(logger, state, item, accounts, err)
 		return
 	}
-	item.nextPollAt = now.Add(pollBackoff(item, options))
+	next := now.Add(pollBackoff(item, options))
+	// When gating is on and a new ledger has not yet closed since this item was
+	// last observed, there is no point waking before the next expected close --
+	// push the wake-up out to it so the item sleeps through the inter-close
+	// interval rather than waking only to be gate-deferred.
+	if options.ledgerGated && ledgerGateBlocks(item, clock) {
+		if aligned := nextCloseProjection(now, item.lastObservedCloseUnix); aligned.After(next) {
+			next = aligned
+		}
+	}
+	item.nextPollAt = next
 	heap.Push(queue, item)
 }
 
@@ -435,6 +588,61 @@ func pollBackoff(item *scheduledPollItem, options pollSchedulerOptions) time.Dur
 		return 0
 	}
 	return backoff
+}
+
+// runLatestLedgerTicker is the fallback that keeps the shared ledger clock
+// advancing when poll traffic is too sparse to do so (the drain tail). It paces
+// to the close cadence -- waking shortly after the next close is expected from
+// the last known close time -- and skips the (whole-ledger-marshaling)
+// getLatestLedger call entirely when poll responses have refreshed the clock
+// within ledgerClockStaleness. A close that ran late (sequence did not advance)
+// triggers a short retry instead of waiting another full interval.
+func runLatestLedgerTicker(ctx context.Context, stop <-chan struct{}, observer latestLedgerObserver, clock *ledgerClock) {
+	for {
+		var delay time.Duration
+		if closeUnix := clock.latestCloseUnix(); closeUnix > 0 {
+			next := time.Unix(closeUnix, 0).Add(estimatedLedgerCloseInterval).Add(estimatedRPCIndexingLag)
+			delay = time.Until(next)
+		}
+		if delay < ledgerGateRecheckFloor {
+			delay = ledgerGateRecheckFloor
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-stop:
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		// Skip the heavy call while poll responses are keeping the clock fresh.
+		if clock.fresh(time.Now()) {
+			continue
+		}
+		before := clock.latestSequence()
+		seq, closeUnix, err := observer.GetLatestLedgerSeq(ctx)
+		if err != nil {
+			continue
+		}
+		clock.observe(seq, closeUnix, time.Now())
+		if seq <= before {
+			// Close ran late; recheck soon rather than after a full interval.
+			timer := time.NewTimer(ledgerTickerLateRetry)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			case <-stop:
+				timer.Stop()
+				return
+			case <-timer.C:
+			}
+		}
+	}
 }
 
 func timeoutPendingPollItems(logger *log.Entry, state *attackState, queue *pollScheduleHeap, accounts accountLeaseManager, err error) {

--- a/cmd/tx-load-test/benchmark/runner_polling.go
+++ b/cmd/tx-load-test/benchmark/runner_polling.go
@@ -396,6 +396,13 @@ func timeoutScheduledPollItem(logger *log.Entry, state *attackState, item *sched
 		logger.WithError(err).Debugf("poll failed: hash=%s", item.item.hash)
 	}
 	atomic.AddUint64(&state.ambiguous, 1)
+	// A poll timeout leaves the on-chain outcome genuinely ambiguous: the tx may
+	// have been included (sequence consumed) or evicted (sequence untouched), and
+	// the poller simply could not confirm in time. Neither optimistic assumption
+	// is safe -- rolling the sequence back reuses a consumed number and assuming
+	// consumed skips one -- both yield txBAD_SEQ. Route through ReleaseAmbiguous
+	// so the recovery loop reloads chain truth before the account is reused. The
+	// recovery loop is parallelized (see runRecoveryLoop) so this stays cheap.
 	releaseAmbiguous(accounts, item.item.rpcID)
 }
 

--- a/cmd/tx-load-test/benchmark/runner_polling_test.go
+++ b/cmd/tx-load-test/benchmark/runner_polling_test.go
@@ -122,6 +122,8 @@ func TestPollSchedulerAllowsOneFinalAttemptForAlreadyExpiredItem(t *testing.T) {
 	waitForPollWaitGroup(t, wg)
 
 	require.Equal(t, []string{"expired"}, client.calls())
+	// A poll timeout leaves the sequence state ambiguous, so the account is
+	// released ambiguous (reload chain truth via recovery) rather than reused.
 	require.Equal(t, []int64{33}, leases.ambiguousReleases)
 	_, _, pollErr := state.pollSnapshot()
 	require.Equal(t, uint64(1), pollErr)

--- a/cmd/tx-load-test/benchmark/runner_polling_test.go
+++ b/cmd/tx-load-test/benchmark/runner_polling_test.go
@@ -233,6 +233,108 @@ func TestNewScheduledPollItemAppliesPredictedFirstPoll(t *testing.T) {
 	require.Equal(t, now.Add(25*time.Second), scheduled.pollDeadline)
 }
 
+func TestLedgerClockObserveKeepsMaxAndTracksFreshness(t *testing.T) {
+	clock := &ledgerClock{}
+	require.Equal(t, uint32(0), clock.latestSequence())
+	require.False(t, clock.fresh(time.Unix(100, 0)))
+
+	clock.observe(50, 1000, time.Unix(100, 0))
+	require.Equal(t, uint32(50), clock.latestSequence())
+	require.Equal(t, int64(1000), clock.latestCloseUnix())
+
+	// A lower sequence is ignored (monotonic), and does not refresh.
+	clock.observe(40, 999, time.Unix(200, 0))
+	require.Equal(t, uint32(50), clock.latestSequence())
+	require.Equal(t, int64(1000), clock.latestCloseUnix())
+
+	// A higher sequence advances and refreshes.
+	clock.observe(51, 1005, time.Unix(300, 0))
+	require.Equal(t, uint32(51), clock.latestSequence())
+	require.Equal(t, int64(1005), clock.latestCloseUnix())
+
+	// Freshness is measured from the last advancing update (t=300).
+	require.True(t, clock.fresh(time.Unix(300, 0).Add(ledgerClockStaleness-time.Second)))
+	require.False(t, clock.fresh(time.Unix(300, 0).Add(ledgerClockStaleness+time.Second)))
+}
+
+func TestLedgerGateBlocksUntilLedgerAdvances(t *testing.T) {
+	clock := &ledgerClock{}
+
+	// No clock info yet, or no item observation yet: never blocks (fall back to
+	// time-based scheduling).
+	require.False(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 100}, clock))
+	clock.observe(100, 0, time.Unix(1, 0))
+	require.False(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 0}, clock))
+
+	// Clock has not advanced past the item's last-observed ledger: block.
+	require.True(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 100}, clock))
+	require.True(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 101}, clock))
+
+	// Clock advances: items at/under the new ledger become eligible.
+	clock.observe(101, 0, time.Unix(2, 0))
+	require.False(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 100}, clock))
+	require.True(t, ledgerGateBlocks(&scheduledPollItem{lastObservedLatestLedger: 101}, clock))
+}
+
+func TestNextCloseProjectionAlignsToNextCloseWithFloor(t *testing.T) {
+	now := time.Unix(1000, 0)
+	// No close-time hint: fall back to the recheck floor.
+	require.Equal(t, now.Add(ledgerGateRecheckFloor), nextCloseProjection(now, 0))
+
+	// Last close at t=998; next close+index ~ 998+5+1 = 1004, which is after the
+	// floor, so use it.
+	got := nextCloseProjection(now, 998)
+	want := time.Unix(998, 0).Add(estimatedLedgerCloseInterval).Add(estimatedRPCIndexingLag)
+	require.Equal(t, want, got)
+
+	// Last close far in the past: projection is before the floor, so floor wins.
+	require.Equal(t, now.Add(ledgerGateRecheckFloor), nextCloseProjection(now, 100))
+}
+
+func TestPollSchedulerGatedDefersRepollUntilLedgerAdvances(t *testing.T) {
+	// One tx that stays NOT_FOUND at the same ledger across early polls, then
+	// SUCCEEDS once the ledger advances. With the gate on, the scheduler must
+	// not burn repeated polls while the ledger is unchanged: total attempts
+	// should be small (one per observed ledger), not one per backoff tick.
+	state := newAttackState(1)
+	now := time.Now()
+	state.hashes <- pollItem{hash: "tx", rpcID: 7, submittedAt: now, submitLatestLedger: 100}
+	close(state.hashes)
+
+	client := newScriptedPollClient(map[string][]scriptedPollResponse{
+		"tx": {
+			// attempt 1 @ ledger 100 -> NOT_FOUND
+			{response: protocol.GetTransactionResponse{LatestLedger: 100, TransactionDetails: protocol.TransactionDetails{Status: "NOT_FOUND"}}},
+			// attempt 2 @ ledger 101 -> SUCCESS (gate should have waited for the advance)
+			{response: protocol.GetTransactionResponse{LatestLedger: 101, TransactionDetails: protocol.TransactionDetails{Status: protocol.TransactionStatusSuccess, Ledger: 101}}},
+			// safety net if the gate misbehaves and over-polls:
+			{response: protocol.GetTransactionResponse{LatestLedger: 101, TransactionDetails: protocol.TransactionDetails{Status: protocol.TransactionStatusSuccess, Ledger: 101}}},
+		},
+	})
+	leases := &fakeLeaseManager{}
+
+	_, wg := startPollSchedulerWithClient(context.Background(), nilLogger(), client, state, leases, "sac-transfer", nil, pollSchedulerOptions{
+		maxConcurrency: 1,
+		batchSize:      1,
+		timeout:        200 * time.Millisecond,
+		attemptTimeout: time.Second,
+		initialBackoff: 5 * time.Millisecond,
+		maxBackoff:     5 * time.Millisecond,
+		ledgerGated:    true,
+	})
+	waitForPollWaitGroup(t, wg)
+
+	// The clock only advances via the responses themselves here (scripted client
+	// has no latest-ledger observer). After attempt 1 reports ledger 100, the
+	// item is gated at ledger 100; nothing else advances the clock, so the item
+	// stays deferred until its deadline and then times out -- i.e. the gate
+	// correctly suppresses redundant same-ledger polls.
+	calls := client.calls()
+	require.Equal(t, []string{"tx"}, calls, "gate must suppress same-ledger re-polls; got %v", calls)
+	_, _, pollErr := state.pollSnapshot()
+	require.Equal(t, uint64(1), pollErr)
+}
+
 func waitForPollWaitGroup(t *testing.T, wg *sync.WaitGroup) {
 	t.Helper()
 	done := make(chan struct{})

--- a/cmd/tx-load-test/benchmark/runner_polling_test.go
+++ b/cmd/tx-load-test/benchmark/runner_polling_test.go
@@ -131,6 +131,108 @@ func TestPollSchedulerAllowsOneFinalAttemptForAlreadyExpiredItem(t *testing.T) {
 	require.Equal(t, []uint32{5}, snapshot.timeoutDistances)
 }
 
+func TestFirstPollAtPredictsNextCloseAndIndexWindow(t *testing.T) {
+	// Submit at wall-clock t=10s; RPC reports last close was at t=8s (2s ago).
+	// Next close expected at t=8+5=13s; indexed ~t=14s after the 1s lag.
+	// First poll should fire at exactly t=14s -- a delay of 4s from submit.
+	now := time.Unix(10, 0)
+	item := pollItem{submittedAt: now, submitLatestLedgerCloseTime: 8}
+	got := firstPollAt(item, now, minFirstPollDelay)
+	want := time.Unix(8, 0).Add(estimatedLedgerCloseInterval).Add(estimatedRPCIndexingLag)
+	require.Equal(t, want, got)
+	require.Equal(t, 4*time.Second, got.Sub(now))
+}
+
+func TestFirstPollAtFloorsWhenPredictionIsInPast(t *testing.T) {
+	// Submit at t=20s, last close was at t=10s (10s ago). The predicted
+	// next-close moment (t=15s) is already past; fall back to the floor.
+	now := time.Unix(20, 0)
+	item := pollItem{submittedAt: now, submitLatestLedgerCloseTime: 10}
+	got := firstPollAt(item, now, minFirstPollDelay)
+	require.Equal(t, now.Add(minFirstPollDelay), got)
+}
+
+func TestFirstPollAtFloorsWhenCloseTimeMissing(t *testing.T) {
+	now := time.Unix(100, 0)
+	got := firstPollAt(pollItem{submittedAt: now}, now, minFirstPollDelay)
+	require.Equal(t, now.Add(minFirstPollDelay), got)
+}
+
+func TestFirstPollAtImmediateWhenFloorIsZero(t *testing.T) {
+	// Tests pass firstPollDelay=0 to keep their immediate-poll semantics.
+	// Without a close-time hint, the result is exactly now.
+	now := time.Unix(100, 0)
+	got := firstPollAt(pollItem{submittedAt: now}, now, 0)
+	require.Equal(t, now, got)
+}
+
+func TestPollBackoffIsLinearArithmeticStepCappedAtMax(t *testing.T) {
+	opts := pollSchedulerOptions{
+		initialBackoff: 500 * time.Millisecond,
+		maxBackoff:     3500 * time.Millisecond,
+		jitter:         false,
+	}.normalized()
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 500 * time.Millisecond},
+		{2, 1000 * time.Millisecond},
+		{3, 1500 * time.Millisecond},
+		{4, 2000 * time.Millisecond},
+		{5, 2500 * time.Millisecond},
+		{6, 3000 * time.Millisecond},
+		{7, 3500 * time.Millisecond},
+		{8, 3500 * time.Millisecond},  // capped
+		{20, 3500 * time.Millisecond}, // capped
+	}
+	for _, c := range cases {
+		got := pollBackoff(&scheduledPollItem{attempt: c.attempt}, opts)
+		require.Equal(t, c.want, got, "attempt %d", c.attempt)
+	}
+}
+
+func TestPollBackoffJitterStaysWithinTenPercentWindow(t *testing.T) {
+	// At cap (3500ms), jitter window = 350ms but capped at 250ms (per code).
+	opts := pollSchedulerOptions{
+		initialBackoff: 500 * time.Millisecond,
+		maxBackoff:     3500 * time.Millisecond,
+		jitter:         true,
+	}.normalized()
+	// Run several distinct (submitIndex, attempt) combos to exercise the
+	// jitter seed and confirm bounds.
+	for _, attempt := range []int{1, 3, 7, 10} {
+		base := time.Duration(min(attempt, 7)) * 500 * time.Millisecond
+		jitterCap := min(base/10, 250*time.Millisecond)
+		for idx := uint64(0); idx < 20; idx++ {
+			got := pollBackoff(&scheduledPollItem{submitIndex: idx, attempt: attempt}, opts)
+			require.GreaterOrEqual(t, got, base-jitterCap, "attempt=%d idx=%d", attempt, idx)
+			require.LessOrEqual(t, got, base+jitterCap, "attempt=%d idx=%d", attempt, idx)
+			require.LessOrEqual(t, got, opts.maxBackoff)
+		}
+	}
+}
+
+func TestNewScheduledPollItemAppliesPredictedFirstPoll(t *testing.T) {
+	// End-to-end: a poll item carrying a close-time hint should schedule its
+	// first poll at the predicted close+index window, not at "now". This is
+	// the production-path assertion that the prediction is wired through.
+	now := time.Unix(1000, 0)
+	item := pollItem{
+		hash:                        "abc",
+		submittedAt:                 now,
+		submitLatestLedgerCloseTime: 998,
+	}
+	opts := pollSchedulerOptions{
+		timeout:        25 * time.Second,
+		firstPollDelay: minFirstPollDelay,
+	}.normalized()
+	scheduled := newScheduledPollItem(item, 0, now, opts)
+	wantFirstPoll := time.Unix(998, 0).Add(estimatedLedgerCloseInterval).Add(estimatedRPCIndexingLag)
+	require.Equal(t, wantFirstPoll, scheduled.nextPollAt)
+	require.Equal(t, now.Add(25*time.Second), scheduled.pollDeadline)
+}
+
 func waitForPollWaitGroup(t *testing.T, wg *sync.WaitGroup) {
 	t.Helper()
 	done := make(chan struct{})

--- a/cmd/tx-load-test/benchmark/runner_polling_test.go
+++ b/cmd/tx-load-test/benchmark/runner_polling_test.go
@@ -1,0 +1,144 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stretchr/testify/require"
+)
+
+type scriptedPollResponse struct {
+	response protocol.GetTransactionResponse
+	err      error
+}
+
+type scriptedPollClient struct {
+	mu        sync.Mutex
+	scripts   map[string][]scriptedPollResponse
+	batches   [][]string
+	callCount map[string]int
+}
+
+func newScriptedPollClient(scripts map[string][]scriptedPollResponse) *scriptedPollClient {
+	return &scriptedPollClient{scripts: scripts, callCount: make(map[string]int)}
+}
+
+func (c *scriptedPollClient) GetTransactions(_ context.Context, requests []transactionPollRequest) ([]transactionPollAttemptResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	batch := make([]string, len(requests))
+	results := make([]transactionPollAttemptResult, len(requests))
+	for i, request := range requests {
+		batch[i] = request.Hash
+		attempt := c.callCount[request.Hash]
+		c.callCount[request.Hash]++
+		responses := c.scripts[request.Hash]
+		if attempt >= len(responses) {
+			results[i] = transactionPollAttemptResult{ID: request.ID, Hash: request.Hash, Err: fmt.Errorf("unexpected poll attempt for %s", request.Hash)}
+			continue
+		}
+		results[i] = transactionPollAttemptResult{
+			ID:       request.ID,
+			Hash:     request.Hash,
+			Response: responses[attempt].response,
+			Err:      responses[attempt].err,
+		}
+	}
+	c.batches = append(c.batches, batch)
+	return results, nil
+}
+
+func (c *scriptedPollClient) calls() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0)
+	for _, batch := range c.batches {
+		out = append(out, batch...)
+	}
+	return out
+}
+
+func TestPollSchedulerRequeuesNonTerminalWithoutStarvingNewerDueItems(t *testing.T) {
+	state := newAttackState(2)
+	now := time.Now()
+	state.hashes <- pollItem{hash: "old", rpcID: 11, submittedAt: now, submitLatestLedger: 100}
+	state.hashes <- pollItem{hash: "new", rpcID: 22, submittedAt: now, submitLatestLedger: 100}
+	close(state.hashes)
+
+	client := newScriptedPollClient(map[string][]scriptedPollResponse{
+		"old": {
+			{response: protocol.GetTransactionResponse{LatestLedger: 101, TransactionDetails: protocol.TransactionDetails{Status: "NOT_FOUND"}}},
+			{response: protocol.GetTransactionResponse{LatestLedger: 103, TransactionDetails: protocol.TransactionDetails{Status: protocol.TransactionStatusSuccess, Ledger: 103}}},
+		},
+		"new": {
+			{response: protocol.GetTransactionResponse{LatestLedger: 102, TransactionDetails: protocol.TransactionDetails{Status: protocol.TransactionStatusSuccess, Ledger: 102}}},
+		},
+	})
+	leases := &fakeLeaseManager{}
+
+	_, wg := startPollSchedulerWithClient(context.Background(), nilLogger(), client, state, leases, "soroswap", nil, pollSchedulerOptions{
+		maxConcurrency: 1,
+		batchSize:      1,
+		timeout:        time.Second,
+		attemptTimeout: time.Second,
+		initialBackoff: 20 * time.Millisecond,
+		maxBackoff:     20 * time.Millisecond,
+	})
+	waitForPollWaitGroup(t, wg)
+
+	require.Equal(t, []string{"old", "new", "old"}, client.calls())
+	require.Equal(t, []int64{22, 11}, leases.consumedReleases)
+	included, onChainFail, pollErr := state.pollSnapshot()
+	require.Equal(t, uint64(2), included)
+	require.Equal(t, uint64(0), onChainFail)
+	require.Equal(t, uint64(0), pollErr)
+}
+
+func TestPollSchedulerAllowsOneFinalAttemptForAlreadyExpiredItem(t *testing.T) {
+	state := newAttackState(1)
+	state.hashes <- pollItem{hash: "expired", rpcID: 33, submittedAt: time.Now().Add(-time.Second), submitLatestLedger: 100}
+	close(state.hashes)
+
+	client := newScriptedPollClient(map[string][]scriptedPollResponse{
+		"expired": {
+			{response: protocol.GetTransactionResponse{LatestLedger: 105, TransactionDetails: protocol.TransactionDetails{Status: "NOT_FOUND"}}},
+		},
+	})
+	leases := &fakeLeaseManager{}
+
+	_, wg := startPollSchedulerWithClient(context.Background(), nilLogger(), client, state, leases, "soroswap", nil, pollSchedulerOptions{
+		maxConcurrency: 1,
+		batchSize:      1,
+		timeout:        time.Millisecond,
+		attemptTimeout: time.Second,
+		initialBackoff: time.Millisecond,
+		maxBackoff:     time.Millisecond,
+	})
+	waitForPollWaitGroup(t, wg)
+
+	require.Equal(t, []string{"expired"}, client.calls())
+	require.Equal(t, []int64{33}, leases.ambiguousReleases)
+	_, _, pollErr := state.pollSnapshot()
+	require.Equal(t, uint64(1), pollErr)
+	snapshot := state.ledgerStats.snapshot()
+	require.Equal(t, []uint32{5}, snapshot.timeoutDistances)
+}
+
+func waitForPollWaitGroup(t *testing.T, wg *sync.WaitGroup) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("poll scheduler did not finish")
+	}
+}

--- a/cmd/tx-load-test/benchmark/runner_test.go
+++ b/cmd/tx-load-test/benchmark/runner_test.go
@@ -532,6 +532,41 @@ func TestSummarizeDiagnosticEventsUsesReadableTokens(t *testing.T) {
 	require.Equal(t, "trying to access an archived contract data entry | Balance", summary)
 }
 
+func TestSummarizeDiagnosticEventsIncludesErrorAndCallContext(t *testing.T) {
+	summary := summarizeDiagnosticEvents([]string{
+		mustDiagnosticEventXDR(t, []xdr.ScVal{
+			mustScSymbol("fn_call"),
+			mustScSymbol("transfer"),
+		}, mustScVec(
+			mustScAccountAddress(t, keypair.MustRandom().Address()),
+			mustScAccountAddress(t, keypair.MustRandom().Address()),
+		)),
+		mustDiagnosticEventXDR(t, []xdr.ScVal{
+			mustScSymbol("error"),
+			mustScString("trying to access an archived contract data entry"),
+		}, mustScVec(
+			mustScSymbol("Balance"),
+			mustScAccountAddress(t, keypair.MustRandom().Address()),
+		)),
+	})
+	require.Equal(t, "trying to access an archived contract data entry | Balance ; fn_call | transfer", summary)
+}
+
+func TestSummarizeDiagnosticEventsKeepsMoreStableTokens(t *testing.T) {
+	summary := summarizeDiagnosticEvents([]string{
+		mustDiagnosticEventXDR(t, []xdr.ScVal{
+			mustScSymbol("error"),
+			mustScString("contract invocation failed"),
+		}, mustScVec(
+			mustScSymbol("transfer"),
+			mustScSymbol("allowance"),
+			mustScSymbol("Balance"),
+			mustScString("insufficient allowance"),
+		)),
+	})
+	require.Equal(t, "contract invocation failed | transfer | allowance | Balance | insufficient allowance", summary)
+}
+
 func TestSummarizeDiagnosticEventsIgnoresDynamicAddresses(t *testing.T) {
 	firstAddress := keypair.MustRandom().Address()
 	secondAddress := keypair.MustRandom().Address()

--- a/cmd/tx-load-test/benchmark/runner_test.go
+++ b/cmd/tx-load-test/benchmark/runner_test.go
@@ -81,7 +81,7 @@ func TestPollWorkerCountBounds(t *testing.T) {
 
 func TestDefaultMetricsFileNameIncludesSecondPrecisionTimestampAndMode(t *testing.T) {
 	name := DefaultMetricsFileName(config.ModeSACTransfer, time.Date(2026, 4, 30, 1, 2, 3, 987654321, time.UTC))
-	require.Equal(t, "tx-load-test-metrics-20260430T010203Z-sac-transfer.ndjson", name)
+	require.Equal(t, filepath.Join("metrics", "tx-load-test-metrics-20260430T010203Z-sac-transfer.ndjson"), name)
 }
 
 func TestWorkloadMetricsReportIncludesStdoutMetrics(t *testing.T) {

--- a/cmd/tx-load-test/benchmark/runner_test.go
+++ b/cmd/tx-load-test/benchmark/runner_test.go
@@ -79,6 +79,12 @@ func TestPollWorkerCountBounds(t *testing.T) {
 	require.Equal(t, 1600, pollWorkerCount(2_000))
 }
 
+func TestBenchmarkTimeoutsKeepPollTrailingTransactionExpiry(t *testing.T) {
+	require.Equal(t, 20, benchmarkTransactionTimeoutSecs)
+	require.Equal(t, 25*time.Second, pollTimeout)
+	require.Greater(t, pollTimeout, time.Duration(benchmarkTransactionTimeoutSecs)*time.Second)
+}
+
 func TestDefaultMetricsFileNameIncludesSecondPrecisionTimestampAndMode(t *testing.T) {
 	name := DefaultMetricsFileName(config.ModeSACTransfer, time.Date(2026, 4, 30, 1, 2, 3, 987654321, time.UTC))
 	require.Equal(t, filepath.Join("metrics", "tx-load-test-metrics-20260430T010203Z-sac-transfer.ndjson"), name)

--- a/cmd/tx-load-test/benchmark/sac_transfer.go
+++ b/cmd/tx-load-test/benchmark/sac_transfer.go
@@ -393,17 +393,23 @@ func remapArchivedSorobanEntries(ext xdr.SorobanTransactionDataExt, indexRemap [
 		}
 		remapped = append(remapped, xdr.Uint32(newIdx))
 	}
-	if len(remapped) == 0 {
+	return buildArchivedSorobanExt(remapped)
+}
+
+// buildArchivedSorobanExt assembles a SorobanTransactionDataExt from a set of
+// read-write footprint indices that core must auto-restore. It sorts and
+// dedups (core requires ascending, unique indices) and downgrades to V0 when
+// the set is empty. Distinct source indices can collapse to the same new index
+// if a rewrite merges entries, hence the dedup.
+func buildArchivedSorobanExt(indices []xdr.Uint32) xdr.SorobanTransactionDataExt {
+	if len(indices) == 0 {
 		return xdr.SorobanTransactionDataExt{V: 0}
 	}
-	slices.Sort(remapped)
-	// Deduplicate post-sort. Distinct old indices can collapse to the same
-	// new index if two simulator-side entries got merged by the rewrite (not
-	// expected for SAC, but defensive against future rewrite shapes).
-	remapped = slices.Compact(remapped)
+	slices.Sort(indices)
+	indices = slices.Compact(indices)
 	return xdr.SorobanTransactionDataExt{
 		V:           1,
-		ResourceExt: &xdr.SorobanResourcesExtV0{ArchivedSorobanEntries: remapped},
+		ResourceExt: &xdr.SorobanResourcesExtV0{ArchivedSorobanEntries: indices},
 	}
 }
 

--- a/cmd/tx-load-test/benchmark/sac_transfer.go
+++ b/cmd/tx-load-test/benchmark/sac_transfer.go
@@ -1,9 +1,11 @@
 package benchmark
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand/v2"
+	"slices"
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 
@@ -145,11 +147,15 @@ func (sacTransferMode) NewTargeter(ctx context.Context, rpcURL string, st *state
 	// "trying to access contract instance outside of the footprint".
 	// The per-SAC footprint is used as a template: only the two trustline
 	// keys are substituted per request; all ReadOnly entries returned by the
-	// simulator are kept as-is.
+	// simulator are kept as-is. Per-SAC Resources / ResourceFee / Ext are
+	// preserved because protocol-23 autorestore can mark each SAC's archived
+	// entries independently and the resource fee scales with whichever SAC
+	// instance needs inline restoration.
 	var (
-		simResources          xdr.SorobanResources
-		simResourceFee        xdr.Int64
+		simResources          [3]xdr.SorobanResources
+		simResourceFees       [3]xdr.Int64
 		simFootprintTemplates [3]xdr.LedgerFootprint
+		simDataExts           [3]xdr.SorobanTransactionDataExt
 	)
 	for i := range sacIDs {
 		simTxSource := txSourceAccounts[0]
@@ -170,10 +176,9 @@ func (sacTransferMode) NewTargeter(ctx context.Context, rpcURL string, st *state
 			return nil, fmt.Errorf("pre-simulate SAC[%d] transfer: %w", i, err)
 		}
 		simFootprintTemplates[i] = simTemplate.simulation.Footprint
-		// All three SACs share the same WASM and logic; use the last
-		// simulation's resource numbers (they should be identical).
-		simResources = simTemplate.simulation.Resources
-		simResourceFee = simTemplate.simulation.ResourceFee
+		simResources[i] = simTemplate.simulation.Resources
+		simResourceFees[i] = simTemplate.simulation.ResourceFee
+		simDataExts[i] = simTemplate.simulation.Ext
 	}
 
 	// Pre-load the on-ledger sequence numbers for every participant account.
@@ -217,28 +222,9 @@ func (sacTransferMode) NewTargeter(ctx context.Context, rpcURL string, st *state
 			return fmt.Errorf("parse dst account: %w", err)
 		}
 
-		// Build transfer(src, dst, amount) invocation arguments.
-		args := xdr.ScVec{
-			{Type: xdr.ScValTypeScvAddress, Address: &xdr.ScAddress{
-				Type: xdr.ScAddressTypeScAddressTypeAccount, AccountId: &holderSrcAccID,
-			}},
-			{Type: xdr.ScValTypeScvAddress, Address: &xdr.ScAddress{
-				Type: xdr.ScAddressTypeScAddressTypeAccount, AccountId: &dstAccID,
-			}},
-			{Type: xdr.ScValTypeScvI128, I128: &xdr.Int128Parts{
-				Hi: 0, Lo: xdr.Uint64(sacTransferAmount),
-			}},
-		}
-		invokeArgs := xdr.InvokeContractArgs{
-			ContractAddress: xdr.ScAddress{
-				Type:       xdr.ScAddressTypeScAddressTypeContract,
-				ContractId: &sacID,
-			},
-			FunctionName: "transfer",
-			Args:         args,
-		}
+		invokeArgs := buildSACTransferInvokeArgs(sacID, holderSrcAccID, dstAccID)
 
-		footprint, err := buildSACFootprintFromTemplate(simFootprintTemplates[sacIdx], assetXDR, holderSrcAccID, dstAccID)
+		footprint, dataExt, err := buildSACFootprintFromTemplate(simFootprintTemplates[sacIdx], simDataExts[sacIdx], assetXDR, holderSrcAccID, dstAccID)
 		if err != nil {
 			return fmt.Errorf("build SAC footprint: %w", err)
 		}
@@ -268,11 +254,20 @@ func (sacTransferMode) NewTargeter(ctx context.Context, rpcURL string, st *state
 			}},
 			Resources: xdr.SorobanResources{
 				Footprint:     footprint,
-				Instructions:  simResources.Instructions,
-				DiskReadBytes: simResources.DiskReadBytes,
-				WriteBytes:    simResources.WriteBytes,
+				Instructions:  simResources[sacIdx].Instructions,
+				DiskReadBytes: simResources[sacIdx].DiskReadBytes,
+				WriteBytes:    simResources[sacIdx].WriteBytes,
 			},
-			ResourceFee: simResourceFee,
+			ResourceFee: simResourceFees[sacIdx],
+			// dataExt carries the remapped archivedSorobanEntries: positions
+			// have shifted because buildSACFootprintFromTemplate drops the
+			// template's per-asset trustline entries and appends the actual
+			// src/dst trustlines. Dropped trustline indices are filtered
+			// out (classic trustlines aren't persistent Soroban entries and
+			// don't archive). Surviving indices -- typically the per-SAC
+			// contract instance entry when the SAC is archived -- are
+			// translated to their new positions and re-sorted.
+			SorobanDataExt: dataExt,
 		})
 		if err != nil {
 			return err
@@ -299,6 +294,10 @@ func presimulateSACTransfer(
 		return simulatedInvocationTemplate{}, err
 	}
 
+	return presimulateBenchmarkInvocation(state, txSourceKP, srcKP.Address(), buildSACTransferInvokeArgs(sacID, srcAccID, dstAccID))
+}
+
+func buildSACTransferInvokeArgs(sacID xdr.ContractId, srcAccID, dstAccID xdr.AccountId) xdr.InvokeContractArgs {
 	args := xdr.ScVec{
 		{Type: xdr.ScValTypeScvAddress, Address: &xdr.ScAddress{
 			Type: xdr.ScAddressTypeScAddressTypeAccount, AccountId: &srcAccID,
@@ -310,7 +309,7 @@ func presimulateSACTransfer(
 			Hi: 0, Lo: xdr.Uint64(sacTransferAmount),
 		}},
 	}
-	invokeArgs := xdr.InvokeContractArgs{
+	return xdr.InvokeContractArgs{
 		ContractAddress: xdr.ScAddress{
 			Type:       xdr.ScAddressTypeScAddressTypeContract,
 			ContractId: &sacID,
@@ -318,32 +317,117 @@ func presimulateSACTransfer(
 		FunctionName: "transfer",
 		Args:         args,
 	}
-
-	return presimulateBenchmarkInvocation(state, txSourceKP, srcKP.Address(), invokeArgs)
 }
 
 // buildSACFootprintFromTemplate takes the footprint returned by the simulator for
 // a representative transfer (accounts[0] -> accounts[1]) and substitutes the two
 // ReadWrite trustline keys with the actual src/dst accounts for this request.
-// All ReadOnly entries (contract instance, issuer account, source account read
-// for auth) are kept as-is since they are identical for every invocation.
+// All ReadOnly entries and non-trustline ReadWrite entries returned by the
+// simulator are kept as-is since they are identical for every invocation.
+//
+// When the simulator emits a SorobanTransactionDataExt.V1 with
+// archivedSorobanEntries (protocol-23 autorestore), the indices reference
+// positions in the simulator's RW slice. Because we drop the template's
+// per-asset trustline entries and append new src/dst trustlines at the tail,
+// surviving indices must be remapped to point at the same entries' new
+// positions. Dropped trustline indices are filtered out (classic trustlines
+// don't archive and aren't persistent Soroban entries anyway). The returned
+// extension is sorted in ascending order, which core requires.
 func buildSACFootprintFromTemplate(
 	tmpl xdr.LedgerFootprint,
+	tmplExt xdr.SorobanTransactionDataExt,
 	assetXDR xdr.Asset,
 	src, dst xdr.AccountId,
-) (xdr.LedgerFootprint, error) {
+) (xdr.LedgerFootprint, xdr.SorobanTransactionDataExt, error) {
 	tla := xdr.TrustLineAsset{
 		Type:       assetXDR.Type,
 		AlphaNum4:  assetXDR.AlphaNum4,
 		AlphaNum12: assetXDR.AlphaNum12,
 	}
-	return buildFootprintFromTemplate(
-		tmpl,
-		func() (xdr.LedgerKey, error) {
-			return xdr.LedgerKey{Type: xdr.LedgerEntryTypeTrustline, TrustLine: &xdr.LedgerKeyTrustLine{AccountId: src, Asset: tla}}, nil
-		},
-		func() (xdr.LedgerKey, error) {
-			return xdr.LedgerKey{Type: xdr.LedgerEntryTypeTrustline, TrustLine: &xdr.LedgerKeyTrustLine{AccountId: dst, Asset: tla}}, nil
-		},
+	footprint := xdr.LedgerFootprint{
+		ReadOnly:  append([]xdr.LedgerKey(nil), tmpl.ReadOnly...),
+		ReadWrite: make([]xdr.LedgerKey, 0, len(tmpl.ReadWrite)),
+	}
+	indexRemap := make([]int, len(tmpl.ReadWrite))
+	for i, key := range tmpl.ReadWrite {
+		if isTrustlineKeyForAsset(key, tla) {
+			indexRemap[i] = -1
+			continue
+		}
+		indexRemap[i] = len(footprint.ReadWrite)
+		footprint.ReadWrite = append(footprint.ReadWrite, key)
+	}
+	footprint.ReadWrite = append(
+		footprint.ReadWrite,
+		xdr.LedgerKey{Type: xdr.LedgerEntryTypeTrustline, TrustLine: &xdr.LedgerKeyTrustLine{AccountId: src, Asset: tla}},
+		xdr.LedgerKey{Type: xdr.LedgerEntryTypeTrustline, TrustLine: &xdr.LedgerKeyTrustLine{AccountId: dst, Asset: tla}},
 	)
+	newExt := remapArchivedSorobanEntries(tmplExt, indexRemap)
+	return footprint, newExt, nil
+}
+
+// remapArchivedSorobanEntries translates archivedSorobanEntries indices from
+// the simulator's original read-write footprint to their positions in a
+// rewritten footprint. indexRemap[old] = new index, or < 0 if the entry was
+// dropped. Returns SorobanTransactionDataExt.V0 if no surviving indices
+// remain. Core requires the index list to be sorted ascending and to point
+// only at persistent entries -- callers are responsible for the latter
+// constraint by not dropping persistent entries during the rewrite.
+func remapArchivedSorobanEntries(ext xdr.SorobanTransactionDataExt, indexRemap []int) xdr.SorobanTransactionDataExt {
+	if ext.V != 1 || ext.ResourceExt == nil {
+		return ext
+	}
+	old := ext.ResourceExt.ArchivedSorobanEntries
+	if len(old) == 0 {
+		return xdr.SorobanTransactionDataExt{V: 0}
+	}
+	remapped := make([]xdr.Uint32, 0, len(old))
+	for _, idx := range old {
+		i := int(idx)
+		if i < 0 || i >= len(indexRemap) {
+			continue
+		}
+		newIdx := indexRemap[i]
+		if newIdx < 0 {
+			continue
+		}
+		remapped = append(remapped, xdr.Uint32(newIdx))
+	}
+	if len(remapped) == 0 {
+		return xdr.SorobanTransactionDataExt{V: 0}
+	}
+	slices.Sort(remapped)
+	// Deduplicate post-sort. Distinct old indices can collapse to the same
+	// new index if two simulator-side entries got merged by the rewrite (not
+	// expected for SAC, but defensive against future rewrite shapes).
+	remapped = slices.Compact(remapped)
+	return xdr.SorobanTransactionDataExt{
+		V:           1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{ArchivedSorobanEntries: remapped},
+	}
+}
+
+func isTrustlineKeyForAsset(key xdr.LedgerKey, asset xdr.TrustLineAsset) bool {
+	if key.Type != xdr.LedgerEntryTypeTrustline || key.TrustLine == nil {
+		return false
+	}
+	return trustlineAssetsEqual(key.TrustLine.Asset, asset)
+}
+
+// trustlineAssetsEqual compares two TrustLineAsset values by their canonical
+// XDR encoding. Go's `==` on AlphaNum4/AlphaNum12 walks the embedded AccountId,
+// whose underlying PublicKey carries an `Ed25519 *Uint256` field; built-in
+// struct equality compares those pointer addresses, not the 32 bytes they point
+// at, so two assets with the same issuer parsed from separate XDR responses
+// compare unequal. The marshal-and-compare path is robust against that.
+func trustlineAssetsEqual(a, b xdr.TrustLineAsset) bool {
+	if a.Type != b.Type {
+		return false
+	}
+	aBytes, errA := a.MarshalBinary()
+	bBytes, errB := b.MarshalBinary()
+	if errA != nil || errB != nil {
+		return false
+	}
+	return bytes.Equal(aBytes, bBytes)
 }

--- a/cmd/tx-load-test/benchmark/sequence.go
+++ b/cmd/tx-load-test/benchmark/sequence.go
@@ -7,10 +7,22 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	"github.com/stellar/go-stellar-sdk/keypair"
+	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
+	"github.com/stellar/go-stellar-sdk/xdr"
 
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
 )
+
+// maxLedgerEntryKeys bounds the number of keys sent in a single getLedgerEntries
+// request. stellar-rpc caps keys per request (default 200); larger account sets
+// are split into this many keys per round-trip.
+const maxLedgerEntryKeys = 200
+
+// sequenceLoadChunkConcurrency bounds how many getLedgerEntries chunks are
+// in flight at once. Kept modest so prehydration does not flood the RPC.
+const sequenceLoadChunkConcurrency = 16
 
 type sequenceManager struct {
 	counters []atomic.Int64
@@ -44,39 +56,137 @@ func loadSequenceNumbers(ctx context.Context, st *state.State, accountKPs []*key
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	n := len(accountKPs)
-	seqNums := make([]int64, n)
-	errs := make([]error, n)
+	addresses := make([]string, len(accountKPs))
+	for i, kp := range accountKPs {
+		addresses[i] = kp.Address()
+	}
 
-	const concurrency = 50
-	sem := make(chan struct{}, concurrency)
-	var wg sync.WaitGroup
+	seqByAddress, err := loadSequenceNumbersByAddress(ctx, st.RPCClient, addresses)
+	if err != nil {
+		return nil, err
+	}
 
-	for i := range n {
-		i := i
+	seqNums := make([]int64, len(accountKPs))
+	for i, addr := range addresses {
+		seq, ok := seqByAddress[addr]
+		if !ok {
+			return nil, fmt.Errorf("account[%d] %s: no ledger entry returned", i, addr)
+		}
+		seqNums[i] = seq
+	}
+	return seqNums, nil
+}
+
+// loadSequenceNumbersByAddress returns each account's current on-chain sequence
+// number keyed by address. It batches reads through getLedgerEntries -- which
+// accepts many keys per request -- so a large account set resolves in a handful
+// of round-trips instead of one LoadAccount call each. Keys are chunked to
+// maxLedgerEntryKeys and chunks are fetched concurrently. Addresses with no
+// ledger entry are simply absent from the returned map; callers decide whether
+// that is an error. Duplicate addresses collapse to a single key.
+func loadSequenceNumbersByAddress(ctx context.Context, rpc *rpcclient.Client, addresses []string) (map[string]int64, error) {
+	if rpc == nil {
+		return nil, fmt.Errorf("missing RPC client")
+	}
+
+	keys := make([]string, 0, len(addresses))
+	addressByKey := make(map[string]string, len(addresses))
+	for _, addr := range addresses {
+		key, err := accountLedgerKey(addr)
+		if err != nil {
+			return nil, fmt.Errorf("build ledger key for %s: %w", addr, err)
+		}
+		if _, seen := addressByKey[key]; seen {
+			continue
+		}
+		addressByKey[key] = addr
+		keys = append(keys, key)
+	}
+
+	chunks := chunkStrings(keys, maxLedgerEntryKeys)
+	sem := make(chan struct{}, sequenceLoadChunkConcurrency)
+	var (
+		wg     sync.WaitGroup
+		mu     sync.Mutex
+		result = make(map[string]int64, len(addresses))
+		errs   = make([]error, len(chunks))
+	)
+
+	for ci, chunk := range chunks {
+		ci, chunk := ci, chunk
 		wg.Go(func() {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			acct, err := st.RPCClient.LoadAccount(ctx, accountKPs[i].Address())
+			resp, err := rpc.GetLedgerEntries(ctx, protocol.GetLedgerEntriesRequest{Keys: chunk})
 			if err != nil {
-				errs[i] = err
+				errs[ci] = err
 				return
 			}
-			seq, err := acct.GetSequenceNumber()
-			if err != nil {
-				errs[i] = err
-				return
+			for _, entry := range resp.Entries {
+				addr, ok := addressByKey[entry.KeyXDR]
+				if !ok {
+					continue
+				}
+				seq, err := accountSeqNumFromEntryXDR(entry.DataXDR)
+				if err != nil {
+					errs[ci] = fmt.Errorf("account %s: %w", addr, err)
+					return
+				}
+				mu.Lock()
+				result[addr] = seq
+				mu.Unlock()
 			}
-			seqNums[i] = seq
 		})
 	}
 	wg.Wait()
 
-	for i, err := range errs {
+	for _, err := range errs {
 		if err != nil {
-			return nil, fmt.Errorf("account[%d] load sequence: %w", i, err)
+			return nil, fmt.Errorf("getLedgerEntries: %w", err)
 		}
 	}
-	return seqNums, nil
+	return result, nil
+}
+
+// accountLedgerKey returns the base64-encoded LedgerKey for an account address,
+// matching the encoding stellar-rpc echoes back in LedgerEntryResult.KeyXDR.
+func accountLedgerKey(address string) (string, error) {
+	accountID, err := xdr.AddressToAccountId(address)
+	if err != nil {
+		return "", err
+	}
+	lk, err := accountID.LedgerKey()
+	if err != nil {
+		return "", err
+	}
+	return xdr.MarshalBase64(lk)
+}
+
+// accountSeqNumFromEntryXDR extracts the sequence number from a base64-encoded
+// account LedgerEntryData.
+func accountSeqNumFromEntryXDR(dataXDR string) (int64, error) {
+	if dataXDR == "" {
+		return 0, fmt.Errorf("empty ledger entry data")
+	}
+	var entry xdr.LedgerEntryData
+	if err := xdr.SafeUnmarshalBase64(dataXDR, &entry); err != nil {
+		return 0, fmt.Errorf("decode ledger entry: %w", err)
+	}
+	if entry.Type != xdr.LedgerEntryTypeAccount || entry.Account == nil {
+		return 0, fmt.Errorf("ledger entry is not an account entry")
+	}
+	return int64(entry.Account.SeqNum), nil
+}
+
+// chunkStrings splits items into consecutive slices of at most size elements.
+func chunkStrings(items []string, size int) [][]string {
+	if size <= 0 {
+		size = len(items)
+	}
+	var chunks [][]string
+	for start := 0; start < len(items); start += size {
+		chunks = append(chunks, items[start:min(start+size, len(items))])
+	}
+	return chunks
 }

--- a/cmd/tx-load-test/benchmark/sequence_test.go
+++ b/cmd/tx-load-test/benchmark/sequence_test.go
@@ -1,0 +1,80 @@
+package benchmark
+
+import (
+	"testing"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChunkStrings(t *testing.T) {
+	require.Equal(t, [][]string{{"a", "b"}, {"c", "d"}, {"e"}}, chunkStrings([]string{"a", "b", "c", "d", "e"}, 2))
+	require.Equal(t, [][]string{{"a", "b", "c"}}, chunkStrings([]string{"a", "b", "c"}, 3))
+	require.Equal(t, [][]string{{"a", "b", "c"}}, chunkStrings([]string{"a", "b", "c"}, 10))
+	require.Nil(t, chunkStrings(nil, 5))
+	require.Empty(t, chunkStrings([]string{}, 5))
+	// size <= 0 collapses to a single chunk rather than spinning forever.
+	require.Equal(t, [][]string{{"a", "b"}}, chunkStrings([]string{"a", "b"}, 0))
+}
+
+func TestAccountLedgerKeyMatchesDecodedAccount(t *testing.T) {
+	kp := keypair.MustRandom()
+
+	key, err := accountLedgerKey(kp.Address())
+	require.NoError(t, err)
+	require.NotEmpty(t, key)
+
+	var lk xdr.LedgerKey
+	require.NoError(t, xdr.SafeUnmarshalBase64(key, &lk))
+	require.Equal(t, xdr.LedgerEntryTypeAccount, lk.Type)
+	require.NotNil(t, lk.Account)
+	require.Equal(t, kp.Address(), lk.Account.AccountId.Address())
+
+	// Encoding must be deterministic so KeyXDR echoed by stellar-rpc matches
+	// the key we built and indexed by.
+	again, err := accountLedgerKey(kp.Address())
+	require.NoError(t, err)
+	require.Equal(t, key, again)
+}
+
+func TestAccountLedgerKeyRejectsInvalidAddress(t *testing.T) {
+	_, err := accountLedgerKey("not-a-valid-address")
+	require.Error(t, err)
+}
+
+func TestAccountSeqNumFromEntryXDR(t *testing.T) {
+	kp := keypair.MustRandom()
+	accountID := xdr.MustAddress(kp.Address())
+
+	entry := xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeAccount,
+		Account: &xdr.AccountEntry{
+			AccountId: accountID,
+			SeqNum:    xdr.SequenceNumber(987654321),
+		},
+	}
+	encoded, err := xdr.MarshalBase64(entry)
+	require.NoError(t, err)
+
+	seq, err := accountSeqNumFromEntryXDR(encoded)
+	require.NoError(t, err)
+	require.Equal(t, int64(987654321), seq)
+}
+
+func TestAccountSeqNumFromEntryXDRRejectsNonAccount(t *testing.T) {
+	_, err := accountSeqNumFromEntryXDR("")
+	require.Error(t, err)
+
+	// A non-account entry (e.g. TTL) must be rejected rather than silently
+	// returning a zero sequence.
+	entry := xdr.LedgerEntryData{
+		Type: xdr.LedgerEntryTypeTtl,
+		Ttl:  &xdr.TtlEntry{LiveUntilLedgerSeq: 42},
+	}
+	encoded, err := xdr.MarshalBase64(entry)
+	require.NoError(t, err)
+
+	_, err = accountSeqNumFromEntryXDR(encoded)
+	require.Error(t, err)
+}

--- a/cmd/tx-load-test/benchmark/soroswap.go
+++ b/cmd/tx-load-test/benchmark/soroswap.go
@@ -164,6 +164,10 @@ func (soroswapMode) NewTargeter(ctx context.Context, rpcURL string, st *state.St
 			AuthEntries:       authEntries,
 			Resources:         resources,
 			ResourceFee:       resourceFee,
+			// buildSoroswapFootprint only ever APPENDS new trustline keys at
+			// the tail of ReadWrite; existing entries keep their indices, so
+			// the simulator's archivedSorobanEntries indices remain valid.
+			SorobanDataExt: tmpl.simulation.Ext,
 		})
 		if err != nil {
 			return err

--- a/cmd/tx-load-test/benchmark/tracing.go
+++ b/cmd/tx-load-test/benchmark/tracing.go
@@ -1,7 +1,6 @@
 package benchmark
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,7 +10,6 @@ import (
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 
-	"github.com/stellar/go-stellar-sdk/clients/rpcclient"
 	protocol "github.com/stellar/go-stellar-sdk/protocols/rpc"
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/ledger"
 )
@@ -105,89 +103,51 @@ func traceTargeter(workload string, base vegeta.Targeter, recorder *benchmarkTra
 	}
 }
 
-func pollTransactionWithTrace(
-	ctx context.Context,
-	rpc *rpcclient.Client,
-	hash string,
-	workload string,
-	recorder *benchmarkTraceRecorder,
-) (pollTransactionResult, error) {
-	interval := 500 * time.Millisecond
-	attempt := 0
-	var result pollTransactionResult
-	for {
-		attempt++
-		if recorder != nil {
-			recorder.record(benchmarkTraceRecord{
-				Timestamp: time.Now(),
-				Workload:  workload,
-				Event:     "poll_request",
-				Method:    protocol.GetTransactionMethodName,
-				Hash:      hash,
-				Attempt:   attempt,
-				RequestBody: fmt.Sprintf(`{"hash":%q}`,
-					hash),
-			})
-		}
-
-		resp, err := rpc.GetTransaction(ctx, protocol.GetTransactionRequest{Hash: hash})
-		if err != nil {
-			if recorder != nil {
-				recorder.record(benchmarkTraceRecord{
-					Timestamp: time.Now(),
-					Workload:  workload,
-					Event:     "poll_response",
-					Method:    protocol.GetTransactionMethodName,
-					Hash:      hash,
-					Attempt:   attempt,
-					Error:     err.Error(),
-				})
-			}
-			return result, err
-		}
-		result.response = resp
-		if resp.LatestLedger > 0 {
-			result.lastObservedLatestLedger = resp.LatestLedger
-		}
-
-		resultCode := ""
-		if resp.Status == protocol.TransactionStatusFailed {
-			resultCode = ledger.DecodeTransactionResultCode(resp.ResultXDR)
-		}
-		if recorder != nil {
-			responseBody, marshalErr := json.Marshal(resp)
-			record := benchmarkTraceRecord{
-				Timestamp:         time.Now(),
-				Workload:          workload,
-				Event:             "poll_response",
-				Method:            protocol.GetTransactionMethodName,
-				Hash:              hash,
-				Attempt:           attempt,
-				TransactionStatus: resp.Status,
-				ResultCode:        resultCode,
-			}
-			if marshalErr != nil {
-				record.Error = fmt.Sprintf("marshal poll response: %v", marshalErr)
-			} else {
-				record.ResponseBody = string(responseBody)
-			}
-			recorder.record(record)
-		}
-
-		switch resp.Status {
-		case protocol.TransactionStatusSuccess, protocol.TransactionStatusFailed:
-			return result, nil
-		}
-
-		timer := time.NewTimer(interval)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
-			return result, ctx.Err()
-		case <-timer.C:
-		}
-		interval = min(interval*2, 3500*time.Millisecond)
+func recordPollRequestTrace(workload string, hash string, rpcID int64, attempt int, recorder *benchmarkTraceRecorder) {
+	if recorder == nil {
+		return
 	}
+	recorder.record(benchmarkTraceRecord{
+		Timestamp:   time.Now(),
+		Workload:    workload,
+		Event:       "poll_request",
+		RPCID:       rpcID,
+		Method:      protocol.GetTransactionMethodName,
+		Hash:        hash,
+		Attempt:     attempt,
+		RequestBody: fmt.Sprintf(`{"hash":%q}`, hash),
+	})
+}
+
+func recordPollResponseTrace(workload string, hash string, rpcID int64, attempt int, resp *protocol.GetTransactionResponse, err error, recorder *benchmarkTraceRecorder) {
+	if recorder == nil {
+		return
+	}
+	record := benchmarkTraceRecord{
+		Timestamp: time.Now(),
+		Workload:  workload,
+		Event:     "poll_response",
+		RPCID:     rpcID,
+		Method:    protocol.GetTransactionMethodName,
+		Hash:      hash,
+		Attempt:   attempt,
+	}
+	if err != nil {
+		record.Error = err.Error()
+		recorder.record(record)
+		return
+	}
+	if resp != nil {
+		record.TransactionStatus = resp.Status
+		if resp.Status == protocol.TransactionStatusFailed {
+			record.ResultCode = ledger.DecodeTransactionResultCode(resp.ResultXDR)
+		}
+		responseBody, marshalErr := json.Marshal(resp)
+		if marshalErr != nil {
+			record.Error = fmt.Sprintf("marshal poll response: %v", marshalErr)
+		} else {
+			record.ResponseBody = string(responseBody)
+		}
+	}
+	recorder.record(record)
 }

--- a/cmd/tx-load-test/benchmark/tracing_test.go
+++ b/cmd/tx-load-test/benchmark/tracing_test.go
@@ -121,14 +121,19 @@ func TestPollTransactionWithTraceWritesPollRequestAndResponse(t *testing.T) {
 	defer server.Close()
 
 	rpc := rpcclient.NewClient(server.URL, nil)
-	_, err = pollTransactionWithTrace(context.Background(), rpc, "feedbeef", "simple-payment", recorder)
+	client := newSDKTransactionPollClient(rpc)
+	recordPollRequestTrace("simple-payment", "feedbeef", 7, 1, recorder)
+	results, err := client.GetTransactions(context.Background(), []transactionPollRequest{{ID: 1, Hash: "feedbeef"}})
 	require.NoError(t, err)
+	require.Len(t, results, 1)
+	recordPollResponseTrace("simple-payment", "feedbeef", 7, 1, &results[0].Response, results[0].Err, recorder)
 	require.NoError(t, recorder.Close())
 
 	records := readTraceRecords(t, traceFile)
 	require.Len(t, records, 2)
 	require.Equal(t, "poll_request", records[0].Event)
 	require.Equal(t, "poll_response", records[1].Event)
+	require.Equal(t, int64(7), records[0].RPCID)
 	require.Equal(t, "feedbeef", records[0].Hash)
 	require.Equal(t, protocol.TransactionStatusSuccess, records[1].TransactionStatus)
 }

--- a/cmd/tx-load-test/benchmark/tx_builder.go
+++ b/cmd/tx-load-test/benchmark/tx_builder.go
@@ -31,6 +31,13 @@ type sorobanSendTransactionParams struct {
 	AuthEntries       []xdr.SorobanAuthorizationEntry
 	Resources         xdr.SorobanResources
 	ResourceFee       xdr.Int64
+	// SorobanDataExt carries the simulator's SorobanTransactionDataExt
+	// verbatim. For protocol-23+ autorestore this holds
+	// SorobanResourcesExtV0.ArchivedSorobanEntries: the read-write footprint
+	// indices core will auto-restore inline at apply time. Dropping it forces
+	// apply to fail with invokeHostFunctionEntryArchived even though
+	// ResourceFee already prices the inline restoration.
+	SorobanDataExt xdr.SorobanTransactionDataExt
 }
 
 func buildSorobanSendTransactionBody(params sorobanSendTransactionParams) ([]byte, error) {
@@ -46,6 +53,7 @@ func buildSorobanSendTransactionBody(params sorobanSendTransactionParams) ([]byt
 			SorobanData: &xdr.SorobanTransactionData{
 				Resources:   params.Resources,
 				ResourceFee: params.ResourceFee,
+				Ext:         params.SorobanDataExt,
 			},
 		},
 	}
@@ -54,13 +62,38 @@ func buildSorobanSendTransactionBody(params sorobanSendTransactionParams) ([]byt
 		SourceAccount:        &txnbuild.SimpleAccount{AccountID: params.TxSource.Address(), Sequence: params.Sequence},
 		IncrementSequenceNum: false,
 		Operations:           []txnbuild.Operation{&op},
-		BaseFee:              sampleBenchmarkBaseFee(),
+		BaseFee:              benchmarkInnerBaseFee(params.ResourceFee),
 		Preconditions:        txnbuild.Preconditions{TimeBounds: txnbuild.NewTimeout(benchmarkTransactionTimeoutSecs)},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("build transaction: %w", err)
 	}
 	return buildBenchmarkSendTransactionBody(params.RPCID, params.NetworkPassphrase, params.FeePayerKP, tx, params.Signers...)
+}
+
+// benchmarkInnerBaseFee returns the per-op inclusion fee for a benchmark
+// transaction. It samples from the usual [benchmarkBaseFeeMin,
+// benchmarkBaseFeeMax] range but raises the floor when the simulator-reported
+// resource fee is large (i.e. autorestore or other expensive Soroban work).
+//
+// Stellar-core enforces a self-induced surge price during sustained
+// Soroban-heavy traffic; the inclusion floor scales with how much resource
+// work each tx consumes. Sampling a 10k-100k inclusion fee on a tx whose
+// resource fee is several million stroops underbids that floor and shows up
+// as txINSUFFICIENT_FEE at submit time. Boosting the inclusion fee
+// proportionally is cheap on test networks (the fee payer is funded by
+// friendbot) and lets the fee-bump's totalFee = (numOps+1) * baseFee +
+// resourceFee actually clear the floor.
+func benchmarkInnerBaseFee(resourceFee xdr.Int64) int64 {
+	baseFee := sampleBenchmarkBaseFee()
+	const heavyResourceFeeThreshold xdr.Int64 = 10_000_000
+	if resourceFee >= heavyResourceFeeThreshold {
+		const heavyResourceBaseFeeFloor int64 = 1_000_000
+		if baseFee < heavyResourceBaseFeeFloor {
+			baseFee = heavyResourceBaseFeeFloor
+		}
+	}
+	return baseFee
 }
 
 func buildBenchmarkSendTransactionBody(rpcID int64, networkPassphrase string, feePayerKP *keypair.Full, innerTx *txnbuild.Transaction, signers ...*keypair.Full) ([]byte, error) {

--- a/cmd/tx-load-test/benchmark/tx_builder.go
+++ b/cmd/tx-load-test/benchmark/tx_builder.go
@@ -17,7 +17,7 @@ import (
 
 const requestIDURLFragmentPrefix = "blaster-rpc-id="
 
-const benchmarkTransactionTimeoutSecs = 25
+const benchmarkTransactionTimeoutSecs = 20
 
 type sorobanSendTransactionParams struct {
 	RPCID             int64

--- a/cmd/tx-load-test/benchmark/tx_builder_test.go
+++ b/cmd/tx-load-test/benchmark/tx_builder_test.go
@@ -92,6 +92,83 @@ func TestBuildSorobanSendTransactionBodyBuildsSignedJSONRPCRequest(t *testing.T)
 	require.Equal(t, xdr.ScSymbol("transfer"), op.HostFunction.InvokeContract.FunctionName)
 }
 
+func TestBuildSorobanSendTransactionBodyCarriesAutorestoreExt(t *testing.T) {
+	// Protocol-23+ autorestore signal: simulator returns
+	// SorobanTransactionDataExt.V1 with the indices of footprint.readWrite
+	// entries that core must auto-restore inline. Without this on the
+	// submitted tx apply fails with invokeHostFunctionEntryArchived even
+	// though the inflated resource fee already prices restoration.
+	txSource, err := keypair.Random()
+	require.NoError(t, err)
+	feePayer, err := keypair.Random()
+	require.NoError(t, err)
+	contractID := xdr.ContractId{}
+	invokeArgs := xdr.InvokeContractArgs{
+		ContractAddress: xdr.ScAddress{Type: xdr.ScAddressTypeScAddressTypeContract, ContractId: &contractID},
+		FunctionName:    "transfer",
+	}
+	resourceFee := xdr.Int64(110_000_000)
+	dataExt := xdr.SorobanTransactionDataExt{
+		V: 1,
+		ResourceExt: &xdr.SorobanResourcesExtV0{
+			ArchivedSorobanEntries: []xdr.Uint32{0, 3},
+		},
+	}
+
+	body, err := buildSorobanSendTransactionBody(sorobanSendTransactionParams{
+		RPCID:             7,
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		FeePayerKP:        feePayer,
+		TxSource:          txSource,
+		Sequence:          1,
+		Signers:           []*keypair.Full{txSource},
+		OpSourceAccount:   txSource.Address(),
+		InvokeArgs:        invokeArgs,
+		Resources:         xdr.SorobanResources{Instructions: 1},
+		ResourceFee:       resourceFee,
+		SorobanDataExt:    dataExt,
+	})
+	require.NoError(t, err)
+
+	var request rpcJSONBody
+	require.NoError(t, json.Unmarshal(body, &request))
+	gtx, err := txnbuild.TransactionFromXDR(request.Params["transaction"])
+	require.NoError(t, err)
+	feeBump, ok := gtx.FeeBump()
+	require.True(t, ok)
+
+	op, ok := feeBump.InnerTransaction().Operations()[0].(*txnbuild.InvokeHostFunction)
+	require.True(t, ok)
+	require.NotNil(t, op.Ext.SorobanData)
+	require.Equal(t, int32(1), int32(op.Ext.SorobanData.Ext.V))
+	require.NotNil(t, op.Ext.SorobanData.Ext.ResourceExt)
+	require.Equal(t,
+		[]xdr.Uint32{0, 3},
+		op.Ext.SorobanData.Ext.ResourceExt.ArchivedSorobanEntries,
+	)
+
+	// When the simulator's resource fee crosses heavyResourceFeeThreshold,
+	// benchmarkInnerBaseFee must lift the per-op inclusion fee floor so that
+	// the fee-bump's totalFee covers the inflated inner total. With a
+	// resource fee of 1.1e8 stroops a 10k-100k inclusion sample would leave
+	// the bump 8-10x short of clearing core's surge floor.
+	require.GreaterOrEqual(t, feeBump.InnerTransaction().BaseFee(), int64(1_000_000)+int64(resourceFee))
+}
+
+func TestBenchmarkInnerBaseFeeBoostsFloorForHeavyResourceFee(t *testing.T) {
+	for i := 0; i < 64; i++ {
+		got := benchmarkInnerBaseFee(20_000_000)
+		require.GreaterOrEqual(t, got, int64(1_000_000),
+			"heavy-resource sample %d=%d should not undercut the 1M floor", i, got)
+	}
+	for i := 0; i < 64; i++ {
+		got := benchmarkInnerBaseFee(1_000)
+		require.GreaterOrEqual(t, got, benchmarkBaseFeeMin)
+		require.LessOrEqual(t, got, benchmarkBaseFeeMax,
+			"light-resource sample %d=%d should stay within the normal sample range", i, got)
+	}
+}
+
 func TestPopulateJSONRPCTargetSetsRequestFields(t *testing.T) {
 	target := &vegeta.Target{}
 	body := []byte(`{"ok":true}`)

--- a/cmd/tx-load-test/config/config.go
+++ b/cmd/tx-load-test/config/config.go
@@ -35,8 +35,10 @@ type Config struct {
 	NumberOfAccounts int
 
 	// BaseReserveXLM is the per-account funding amount in XLM.
-	// 0.5 base reserve + 3 x 0.5 trustline entries = 2.0 XLM minimum; an extra
-	// 1.0 XLM is added as a safety margin, giving a default of 3.0 XLM.
+	// On networks with a 0.5 XLM base reserve, an account with three benchmark
+	// asset trustlines needs (2 account reserves + 3 trustline reserves) * 0.5 =
+	// 2.5 XLM locked as minimum balance. The 3.0 XLM default leaves about 0.5
+	// XLM of headroom for incidental fees and future reserve changes.
 	BaseReserveXLM float64
 
 	// LiquidityPerPool is the amount of each asset to deposit into each Soroswap pool.

--- a/cmd/tx-load-test/docs/PLAN.md
+++ b/cmd/tx-load-test/docs/PLAN.md
@@ -8,17 +8,21 @@ Treat this as a design brief plus acceptance criteria.
 
 Build a standalone Stellar Soroban RPC load-testing CLI named `tx-load-test` under `cmd/tx-load-test`.
 
-The tool must support four commands:
+The tool must support five commands:
 
 1. `setup`
-2. `bench`
-3. `teardown`
-4. `sync`
+2. `restore`
+3. `bench`
+4. `teardown`
+5. `sync`
 
-The tool must implement a three-phase lifecycle driven by a JSON state file:
+The tool must implement a state-file-driven lifecycle. `restore` is an
+optional pre-benchmark maintenance step that re-hydrates archived Soroban
+state; `bench` is repeatable; cleanup and reconciliation are explicit.
 
 ```text
-setup  -->  state.json  -->  bench  (repeatable)
+setup  -->  state.json  -->  restore  (optional, pre-benchmark maintenance)
+											 -->  bench     (repeatable)
 											 -->  teardown
 											 -->  sync
 ```
@@ -37,7 +41,7 @@ The reimplementation must preserve these behaviors.
 ### 2.1 CLI shape
 
 - Use `cobra` for the command tree.
-- Provide a root command `tx-load-test` with subcommands `setup`, `bench`, `teardown`, and `sync`.
+- Provide a root command `tx-load-test` with subcommands `setup`, `restore`, `bench`, `teardown`, and `sync`.
 - Root command should print usage when invoked without a subcommand.
 - Build target must remain:
 
@@ -147,7 +151,40 @@ Operational details worth preserving:
 - Soroswap core auto-bootstrap should only be allowed on standalone and futurenet
 - deterministic Soroswap factory/router contract IDs should be derived from stable salts plus fee payer address and network passphrase
 
-### 3.2 `bench`
+### 3.2 `restore`
+
+`restore` is an optional pre-benchmark maintenance command. State files that
+sit idle between tests accumulate archived Soroban state (especially
+`oz-transfer` per-account balances and `soroswap`/account contract data),
+which makes the first benchmark hits fail or pay extra. `restore` probes the
+benchmark-shaped invocations and re-hydrates what it can before a real run.
+
+Flags:
+
+- `--mode`, default `all`; one of `all`, `sac-transfer`, `oz-transfer`, `soroswap`
+- `--dry-run`, default `false`; simulate and report what would need restore, submit nothing
+- `--verify`, default `false`; after restoring, re-run the probes and fail if any still require restore
+- `--account-start`, default `0`; 0-based offset into the selected participant list
+- `--account-limit`, default `0`; max selected accounts per applicable mode (`0` = all)
+- `--progress-interval`, default `100`; log progress every N probes (negative disables)
+- `--rpc-url`, optional override from state
+- `--skip-account-preflight` / `--account-preflight-sample` (default `10`), same semantics as `bench`
+- `--state-file`, default `state.json`
+- `--log-level`, default `info`
+
+Behavior to preserve:
+
+- requires `FEE_PAYER`; validates network passphrase like the other state-consuming commands
+- uses **simulation only** to probe; it does not submit the benchmark transfer/swap invocations
+- per-mode probe scope:
+	- `sac-transfer`: probes the three shared SAC contract instances (participant balances are classic trustlines, not archivable Soroban state)
+	- `oz-transfer`: one probe per selected account so each account's OZ `Balance` contract-data entry is touched
+	- `soroswap`: probes selected holders across both benchmark pools in both swap directions (covers shared router/pair/pool state plus per-account trader data)
+- **legacy restoration**: when simulation returns a `RestorePreamble`, submit a `RestoreFootprint` transaction (unless `--dry-run`) and retry, bounded by a small attempt cap
+- **autorestore awareness** (protocol 23+): when simulation omits a `RestorePreamble` but reports archived read-write entries via `SorobanResourcesExtV0.archivedSorobanEntries`, surface those as `autoRestoreProbes`/`autoRestoreKeys` in the summary but submit no separate transaction — these entries are restored inline by the benchmark's own invocations at apply time (see §7.4). `--verify` must therefore exclude autorestore-only probes when deciding whether restoration is still outstanding, or it will never converge.
+- emit a per-mode summary: probes run, restore-needed probes, restore transactions submitted, autorestore probes/keys, no-op probes, restored read-only/read-write key counts, selected account range/count, elapsed time, and the first few errors. `--dry-run` summaries use "would restore" wording.
+
+### 3.3 `bench`
 
 Flags:
 
@@ -158,6 +195,7 @@ Flags:
 - `--ramp-up`, default `20s`
 - `--rpc-url`, optional override from state
 - `--trace-file`, optional NDJSON submit/poll trace output
+- `--metrics-file`, optional; defaults to a timestamped, mode-named NDJSON file under `metrics/`
 - `--skip-account-preflight`, optional; disables the sampled on-chain participant existence preflight
 - `--account-preflight-sample`, default `10`
 - `--state-file`, default `state.json`
@@ -180,9 +218,12 @@ Benchmark engine expectations:
 - use Vegeta-style attack generation with ramp-up pacing
 - submit traffic through the RPC endpoint using the RPC `sendTransaction` method
 - wrap benchmark submissions in fee-bump envelopes paid by the fee payer while preserving the inner workload transaction semantics
-- maintain a separate poll/drain stage to observe inclusion results
+- sample a per-op inclusion fee per transaction rather than using one fixed value (see §7.2) and raise that floor for resource-heavy transactions
+- thread the simulator's autorestore extension through to each submitted transaction (see §7.4)
+- maintain a separate poll/drain stage to observe inclusion results, scheduled so polling never blocks per transaction (see §7.2)
 - report submission counters, acceptance failures, ambiguous submission outcomes, on-chain inclusion/failure counts, Vegeta metrics, latency percentiles, byte counts, and HTTP code distribution
 - preserve submit-time and on-chain failure summaries, including result-code breakdowns, operation-result breakdowns, and normalized diagnostic summaries when available
+- write a flattened NDJSON metrics file as a first-class output (see §7.5)
 
 Validation rules:
 
@@ -194,7 +235,7 @@ Validation rules:
 - account pool must be large enough for both the Soroban stream and the classic companion stream for the requested duration and rate
 - `sac-transfer` requires valid SAC holder subsets and trustlines in state
 
-### 3.3 `teardown`
+### 3.4 `teardown`
 
 Behavior:
 
@@ -212,7 +253,7 @@ Teardown mechanics to preserve:
 	- remove trustlines then account-merge
 - batching is conservative to avoid signature and operation limits
 
-### 3.4 `sync`
+### 3.5 `sync`
 
 Behavior:
 
@@ -260,6 +301,7 @@ Under `cmd/tx-load-test/`:
 - `main.go`: execute root command
 - `root_cmd.go`: build Cobra root command
 - `setup_cmd.go`
+- `restore_cmd.go`
 - `bench_cmd.go`
 - `teardown_cmd.go`
 - `sync_cmd.go`
@@ -308,13 +350,18 @@ Responsibilities:
 - benchmark config validation
 - source-account sizing math for the Soroban stream and the optional classic companion stream
 - shared source-account lease management for benchmark traffic, including unique request IDs, sequence assignment, and release semantics for retryable, consumed, and ambiguous outcomes
+- a parallel pool of recovery workers that re-load on-chain sequence state for poisoned/ambiguous accounts before reuse (see §7.1)
 - benchmark runners and attack orchestration
-- mode-specific payload generation
-- shared transaction building
+- a poll scheduler that batches `getTransaction`, requeues non-terminal results, and never blocks per transaction (see §7.2)
+- mode-specific payload generation, including per-mode footprint rewrite and autorestore-index remapping (see §7.4)
+- shared transaction building, including the autorestore extension and per-tx fee sampling
+- flattened NDJSON metrics reporting (see §7.5)
+- the `restore` maintenance logic (probing + legacy restore submission + autorestore accounting)
 
-Important design choice to preserve:
+Important design choices to preserve:
 
 - one shared Soroban transaction builder for all Soroban modes rather than ad hoc request construction in each mode
+- `restore` lives alongside the benchmark code because it reuses the same mode payloads and simulation helpers as a probe; it differs only in submitting `RestoreFootprint` (or nothing) instead of the workload invocation
 
 ### 5.5 `soroban`
 
@@ -322,13 +369,14 @@ Use this as the shared low-level Soroban helper package.
 
 Responsibilities:
 
-- simulation helpers
+- simulation helpers, including capturing the simulator's `SorobanTransactionData.Ext` (autorestore extension) alongside resources and footprint
 - footprint manipulation and substitution
 - SCVal/address/encoding helpers
 
 Important design choice:
 
 - simulation and footprint substitution belong in shared helpers, not duplicated in each benchmark mode
+- the simulation result must carry the autorestore extension, not just resources/footprint, or every consumer silently drops it
 
 ### 5.6 `soroswap`
 
@@ -348,7 +396,7 @@ Responsibilities:
 - account derivation from fee payer seed + indices
 - shared submission helpers
 - result polling and transaction outcome decoding
-- benchmark account-count math helpers used by validation
+- benchmark account-count math helpers used by validation, including the source-account reuse-gap and run-budget sizing constants
 
 ### 5.8 `ledger`
 
@@ -398,7 +446,9 @@ This is essential. Recreate both the sizing math and the runtime account-coordin
 - use a shared source-account lease manager at runtime rather than static per-workload partitions
 - preserve capability-aware leasing so workloads that need trustlined-capable sources can require them while other workloads can draw from the broader pool
 - preserve explicit lease release semantics for retryable, consumed, and ambiguous outcomes so local sequence state is not blindly rewound
-- preserve background recovery of ambiguous or poisoned accounts by reloading on-chain sequence state before reuse
+- preserve background recovery of ambiguous or poisoned accounts by reloading on-chain sequence state before reuse. Recovery MUST be parallel (a pool of recovery workers), not a single serialized loop: under load, a single worker blocked on one slow sequence reload lets poisoned accounts accumulate faster than they drain, collapsing the available pool and stalling the whole benchmark.
+- size the pool from a source-account reuse gap (a small number of ledgers a given account should rest between submissions) and a per-run reuse budget, so the pool is large enough to avoid sequence contention at the requested rate and duration
+- load initial on-chain sequence numbers in batches via `getLedgerEntries` (many keys per request, bounded concurrency) rather than one account lookup at a time, so cold start and recovery scale to thousands of accounts
 
 ### 7.2 Transaction submission and polling
 
@@ -411,12 +461,86 @@ This is essential. Recreate both the sizing math and the runtime account-coordin
 - retain distinct visibility into ambiguous submission outcomes versus confirmed retryable or terminal failures
 - surface result-code, op-result, and diagnostic summaries at both submit time and final on-chain outcome time
 
+Fee handling (correctness, not tuning):
+
+- sample a per-op inclusion fee per transaction from a range rather than using one fixed value. Stellar core's surge-pricing comparison requires a strictly greater per-op fee to displace a queued transaction; identical bids tie and all but the first are rejected `txINSUFFICIENT_FEE`. Per-tx sampling makes ties statistically negligible.
+- raise that inclusion-fee floor for resource-heavy transactions (e.g. autorestore-inflated resource fees), so the fee-bump's total fee clears the floor instead of underbidding it.
+
+Polling model (preserve the shape, not the constants):
+
+- do not block a worker per outstanding transaction. Use a scheduler (e.g. a time-ordered queue) that holds pending hashes and dispatches due polls, so a backlog never starves new work.
+- batch `getTransaction` lookups and requeue non-terminal results with backoff rather than busy-waiting; only declare a per-transaction timeout when an overall deadline is exceeded.
+- defer the first poll for a submitted transaction until the next ledger after submission can plausibly have closed and been indexed; polling immediately on submit wastes a guaranteed not-found round trip. The submission response's latest-ledger close time is enough to predict this.
+- a poll timeout leaves the on-chain outcome genuinely ambiguous (the tx may have been included or evicted); release such accounts as ambiguous and route them through recovery rather than optimistically rewinding or advancing the sequence.
+
 ### 7.3 Soroswap mode behavior
 
 - benchmark pools should exist for BLTA/BLTB and BLTB/BLTC style paths
 - swaps should use the router contract
 - setup should ensure the router points at the chosen factory
 - setup should ensure factory/router are initialized correctly when auto-bootstrapped
+
+### 7.4 Soroban state archival and autorestore
+
+This is a correctness requirement, not an optimization. On protocol 23+,
+contract-data entries that go unused archive over time. Idle state files hit
+this constantly: an `oz-transfer` account's `Balance` entry, a `soroswap`
+pool/trader entry, or a contract instance can all be archived by the time a
+benchmark runs. Getting this wrong manifests as `invokeHostFunctionEntryArchived`
+at apply time, even though simulation succeeded.
+
+Preserve the full chain:
+
+- **Capture**: when simulating a benchmark invocation, the simulator may return
+	no legacy `RestorePreamble` but instead populate
+	`SorobanTransactionData.Ext` (`SorobanResourcesExtV0.archivedSorobanEntries`)
+	with the read-write footprint indices it auto-restored. The simulation
+	result must retain this extension, not just resources and footprint.
+- **Reattach**: the shared transaction builder must set this extension on the
+	submitted `SorobanTransactionData`. Core auto-restores the listed entries
+	inline at apply time and prices it into the resource fee. Dropping the
+	extension makes apply reject the archived reads.
+- **Remap across footprint rewrites**: each mode reuses a presimulated template
+	footprint and substitutes per-request keys. The archived indices reference
+	template positions, so they must be remapped to the rewritten footprint's
+	positions. Two distinct cases:
+	- entries that are *kept* in place (e.g. a shared contract instance) keep
+		their archived marker, remapped to the new index;
+	- entries that are *substituted* must have their marker INHERITED by the
+		replacement. This is the subtle one: SAC and soroswap substitute classic
+		trustlines (which never archive), so they only ever carry markers on kept
+		entries; but `oz-transfer` substitutes the per-account balance entries,
+		which ARE the archivable ones. If the substituted entry's template
+		counterpart was archived, the appended actual entry must be marked too.
+	- the resulting index list must stay sorted and unique (core requires it).
+- **`restore` accounting**: probes whose only restoration need is satisfied by
+	autorestore submit no separate transaction; they are reported but rely on the
+	benchmark's own invocations to carry the extension (see §3.2).
+
+The template-reuse approach assumes participant entries share archival state
+(true when balances/state are provisioned together at setup with identical
+TTLs). Per-request simulation would be exact in all cases but defeats the
+template optimization; the inheritance heuristic is the deliberate tradeoff.
+
+### 7.5 Benchmark metrics output
+
+`bench` must write a flattened NDJSON metrics file as a first-class deliverable
+(default path under `metrics/`, timestamped and mode-named; overridable). It is
+separate from the optional `--trace-file` request/response capture.
+
+- one summary record per workload (the Soroban stream and, if enabled, the
+	classic companion stream), combining run/workload parameters, submission
+	counters, on-chain inclusion/failure counters, latency percentiles, Vegeta
+	metrics, and flattened HTTP status-code counts
+- ledger-level metrics are the diagnostically important additions: end-to-end
+	latency (submit start to terminal poll), ledger finality distance (submit
+	latest ledger to inclusion ledger), transactions per finality ledger, and a
+	timeout-distance metric. The gap between finality distance (small) and
+	end-to-end latency (large) is the primary signal that the observation
+	pipeline, not the network, is the bottleneck.
+- additional records for Vegeta error categories with run/workload identity
+- the schema intentionally omits per-ledger count maps and per-request records;
+	those remain trace-file or console concerns
 
 ## 8. Contract Behavior To Recreate
 
@@ -448,6 +572,8 @@ Current test inventory to emulate:
 - `cmd/tx-load-test/benchmark/tx_builder_test.go`
 - `cmd/tx-load-test/benchmark/footprint_test.go`
 - `cmd/tx-load-test/benchmark/runner_test.go`
+- `cmd/tx-load-test/benchmark/runner_polling_test.go`
+- `cmd/tx-load-test/benchmark/restore_test.go`
 - `cmd/tx-load-test/setup/setup_test.go`
 - `cmd/tx-load-test/setup/accounts_test.go`
 - `cmd/tx-load-test/setup/soroswap_core_test.go`
@@ -486,12 +612,34 @@ The recreated suite should cover at least these behaviors.
 - auth entry fixtures are valid for the SDK version in use
 - fee/resource-fee handling is asserted correctly
 - benchmark transaction construction is fee-bumped and signed correctly
+- per-tx inclusion-fee sampling, and the raised fee floor for heavy-resource transactions
+- the autorestore extension is carried onto the submitted transaction body
 
 ### 9.4 Shared Soroban helper tests
 
 - simulation helper behavior
 - footprint replacement/substitution behavior
 - helper SCVal/address conversions
+- simulation captures the autorestore extension (`archivedSorobanEntries`) from the simulator response
+
+### 9.4a Autorestore footprint-remap tests
+
+- archived indices for kept entries remap to their new footprint positions
+- archived indices for substituted entries are inherited by the appended replacements (the `oz-transfer` balance case), while substituted-but-never-archived entries (SAC/soroswap trustlines) carry nothing
+- the resulting archived index list is sorted and unique
+
+### 9.4b Poll-scheduler tests
+
+- non-terminal results requeue with backoff without blocking, and newer due items are not starved
+- an already-expired item still gets one final attempt before timing out
+- a poll timeout releases the account as ambiguous (routed to recovery), not optimistically rewound
+- the first poll is deferred toward the predicted next-close/index window
+
+### 9.4c Restore tests
+
+- per-mode probe selection and account-range slicing
+- legacy `RestorePreamble` probes submit a `RestoreFootprint` (and `--dry-run` submits nothing)
+- autorestore-only probes are counted but submit no transaction, and `--verify` does not treat them as outstanding restoration
 
 ### 9.5 Setup/account tests
 
@@ -511,14 +659,14 @@ The recreated suite should cover at least these behaviors.
 
 - atomic load/save behavior
 - account derivation from indices
-- benchmark account-count helpers and source-account sizing math
+- benchmark account-count helpers and source-account sizing math (reuse gap and run budget)
 - transaction result decoding/polling helpers
 
 ### 9.8 Teardown tests
 
 - batch construction and resumable cleanup behavior
 
-The current full suite passes at approximately 88 tests. The recreated suite does not need the same count, but it should be broad enough that a reviewer can see equivalent coverage.
+The recreated suite does not need a specific test count, but it should be broad enough that a reviewer can see equivalent coverage, now including the polling scheduler, autorestore remap/inheritance, and restore behaviors above.
 
 ## 10. Suggested Implementation Order
 
@@ -554,9 +702,9 @@ Use this order to rebuild the tool with minimum rework.
 
 ### Phase 5: Shared Soroban support
 
-1. Simulation helpers
+1. Simulation helpers (capturing the autorestore extension)
 2. Footprint helpers
-3. Shared tx builder
+3. Shared tx builder (autorestore extension + per-tx fee sampling)
 4. Result polling/submission helpers
 
 ### Phase 6: Soroswap support
@@ -575,20 +723,29 @@ Use this order to rebuild the tool with minimum rework.
 
 ### Phase 8: Bench runners
 
-1. Shared source-account lease manager and sequence coordination
-2. SAC transfer mode
-3. OZ transfer mode
-4. Soroswap swap mode
-5. Parallel simple-payment companion stream
-6. Vegeta metrics and reporting
+1. Shared source-account lease manager, sequence coordination, and parallel recovery workers
+2. Poll scheduler (batched, non-blocking, close-aligned first poll)
+3. Autorestore extension threading and per-mode footprint-remap/inheritance
+4. SAC transfer mode
+5. OZ transfer mode
+6. Soroswap swap mode
+7. Parallel simple-payment companion stream
+8. Vegeta metrics, ledger/finality metrics, and the flattened NDJSON metrics file
 
-### Phase 9: Cleanup and sync
+### Phase 9: Restore maintenance command
+
+1. Per-mode probe construction reusing the bench mode payloads
+2. Legacy `RestoreFootprint` submission with attempt cap
+3. Autorestore accounting and `--verify` convergence
+4. Account-range slicing and progress/summary reporting
+
+### Phase 10: Cleanup and sync
 
 1. Teardown drain/merge batching
 2. Partial-progress persistence
 3. Sync reconciliation
 
-### Phase 10: Documentation and polish
+### Phase 11: Documentation and polish
 
 1. Command docs
 2. State schema docs
@@ -600,17 +757,20 @@ Use this order to rebuild the tool with minimum rework.
 The reimplementation is complete when all of the following are true.
 
 1. `go build -o tx-load-test ./cmd/tx-load-test` succeeds.
-2. The CLI exposes `setup`, `bench`, `teardown`, and `sync` via Cobra.
+2. The CLI exposes `setup`, `restore`, `bench`, `teardown`, and `sync` via Cobra.
 3. Setup creates a reusable JSON state file and bench runs from it.
 4. Setup can be re-run with a higher `--accounts` target and only create the delta.
 5. Standalone/futurenet setup can auto-bootstrap Soroswap core from flat Wasm artifacts.
 6. Public-network setup requires explicit factory/router IDs.
 7. Bench supports `sac-transfer`, `oz-transfer`, and `soroswap`.
 8. Bench optionally runs the companion classic payment stream.
-9. Teardown is resumable and deletes the state file on full success.
-10. Sync removes missing on-chain accounts from persisted state.
-11. Contract artifacts are refreshed via `contracts/update-wasms.sh`.
-12. The test suite covers the same conceptual surface as the current implementation.
+9. Bench against archived state succeeds: the autorestore extension is carried through so apply auto-restores archived entries inline instead of failing with `invokeHostFunctionEntryArchived`.
+10. Bench writes a flattened NDJSON metrics file with ledger finality/inclusion metrics.
+11. Restore probes per mode, submits `RestoreFootprint` for legacy-archived state, accounts for autorestore, and `--verify` converges.
+12. Teardown is resumable and deletes the state file on full success.
+13. Sync removes missing on-chain accounts from persisted state.
+14. Contract artifacts are refreshed via `contracts/update-wasms.sh`.
+15. The test suite covers the same conceptual surface as the current implementation.
 
 ## 12. Things To Avoid
 
@@ -620,6 +780,9 @@ The reimplementation is complete when all of the following are true.
 4. Do not store raw fee payer secrets on disk.
 5. Do not depend on a vendored Soroswap repo at runtime.
 6. Do not make teardown a best-effort shell script; keep it a resumable first-class command.
+7. Do not drop the simulator's autorestore extension when building submitted transactions, and do not lose archived markers when rewriting footprints (especially for substituted entries) — both reintroduce `invokeHostFunctionEntryArchived` failures that pass simulation.
+8. Do not block a poll worker per outstanding transaction, and do not serialize account recovery behind a single worker — both cause the available pool to collapse under sustained load.
+9. Do not use one fixed inclusion fee for all benchmark transactions; identical bids tie under surge pricing and get rejected.
 
 ## 13. Final Note To The Future Agent
 
@@ -631,5 +794,7 @@ If tradeoffs are required, preserve these first:
 4. shared Soroban helpers and shared tx builder
 5. flat contract artifact model plus refresh script
 6. strong validation and comparable tests
+7. autorestore correctness (capture, reattach, remap/inherit) — without it, archived state silently breaks every Soroban mode
+8. the non-blocking poll scheduler and parallel account recovery — they are what keep throughput steady under sustained load rather than spiraling into pool starvation
 
 You do not need to reproduce the exact line structure of the current implementation. You do need to recreate the same operational model, package boundaries, ergonomics, and reliability properties.

--- a/cmd/tx-load-test/restore_cmd.go
+++ b/cmd/tx-load-test/restore_cmd.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/benchmark"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
+)
+
+func buildRestoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore",
+		Short: "Restore archived Soroban state needed by benchmark workloads",
+		Long: `restore runs benchmark-shaped simulations ahead of a load test to find
+archived Soroban state, submits RestoreFootprint transactions when needed, and
+optionally verifies the selected workload footprints are live.
+
+This keeps simulation out of the per-request benchmark hot path. Use restore
+when a state file has been idle long enough that OZ or Soroswap contract data
+may have archived. SAC restore is intentionally limited to shared contract
+state; SAC participant balances are classic trustlines, not Soroban archived
+entries.`,
+		RunE: runRestore,
+	}
+
+	addRuntimeStatePreflightFlags(cmd)
+	cmd.Flags().String("log-level", "info", "Log verbosity: debug | info | warn | error")
+	cmd.Flags().String("rpc-url", "", "Override the RPC URL stored in the state JSON file")
+	cmd.Flags().String("state-file", state.DefaultStateFile, "Path to the state JSON file")
+	cmd.Flags().String("mode", benchmark.RestoreModeAll,
+		fmt.Sprintf("Restore mode: %s | %s | %s | %s", benchmark.RestoreModeAll, config.ModeSACTransfer, config.ModeOZTransfer, config.ModeSoroswap))
+	cmd.Flags().Bool("dry-run", false, "Only simulate and log what would need restore; do not submit RestoreFootprint transactions")
+	cmd.Flags().Bool("verify", false, "After restoring, re-run selected restore probes and fail if any still require restore")
+	cmd.Flags().Int("account-start", 0, "0-based offset into the selected participant account list")
+	cmd.Flags().Int("account-limit", 0, "Maximum selected accounts per applicable mode; 0 means all remaining accounts")
+	cmd.Flags().Int("progress-interval", 100, "Log restore progress every N probes; set negative to disable periodic progress")
+	return cmd
+}
+
+func runRestore(cmd *cobra.Command, _ []string) error {
+	logger, err := makeLogger(cmd, "tx-load-test/restore")
+	if err != nil {
+		return err
+	}
+
+	mode, err := cmd.Flags().GetString("mode")
+	if err != nil {
+		return err
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return err
+	}
+	verify, err := cmd.Flags().GetBool("verify")
+	if err != nil {
+		return err
+	}
+	accountStart, err := cmd.Flags().GetInt("account-start")
+	if err != nil {
+		return err
+	}
+	accountLimit, err := cmd.Flags().GetInt("account-limit")
+	if err != nil {
+		return err
+	}
+	progressInterval, err := cmd.Flags().GetInt("progress-interval")
+	if err != nil {
+		return err
+	}
+
+	stateFile, loaded, err := loadRuntimeStateFromCommand(cmd, state.RuntimePhaseRestore)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := signalCommandContext(cmd, logger, true)
+	defer cancel()
+
+	logger.Infof("loaded state from %s (%d accounts, rpc=%s)", stateFile, len(loaded.Persisted.AccountIndices), loaded.RPCURL)
+	return benchmark.RestoreArchivedState(ctx, logger, loaded.Live, benchmark.RestoreOptions{
+		Mode:             mode,
+		DryRun:           dryRun,
+		Verify:           verify,
+		AccountStart:     accountStart,
+		AccountLimit:     accountLimit,
+		ProgressInterval: progressInterval,
+	})
+}

--- a/cmd/tx-load-test/restore_cmd.go
+++ b/cmd/tx-load-test/restore_cmd.go
@@ -18,11 +18,16 @@ func buildRestoreCmd() *cobra.Command {
 archived Soroban state, submits RestoreFootprint transactions when needed, and
 optionally verifies the selected workload footprints are live.
 
+For soroswap, restore also runs a benchmark-footprint validation pass that
+builds the same rewritten footprints used by benchmark submissions and compares
+them with fresh simulation footprints.
+
 This keeps simulation out of the per-request benchmark hot path. Use restore
-when a state file has been idle long enough that OZ or Soroswap contract data
-may have archived. SAC restore is intentionally limited to shared contract
-state; SAC participant balances are classic trustlines, not Soroban archived
-entries.`,
+when a state file has been idle long enough that benchmark contract data may
+have archived. SAC restore probes selected holder accounts with transfer-shaped
+calls so simulation can report archived SAC WASM/code, contract instance state,
+and any account-specific SAC contract data. SAC participant balances are classic
+trustlines, not Soroban archived entries.`,
 		RunE: runRestore,
 	}
 

--- a/cmd/tx-load-test/root_cmd.go
+++ b/cmd/tx-load-test/root_cmd.go
@@ -15,6 +15,7 @@ func buildRootCmd() *cobra.Command {
 
 	root.AddCommand(buildSetupCmd())
 	root.AddCommand(buildBenchCmd())
+	root.AddCommand(buildRestoreCmd())
 	root.AddCommand(buildTeardownCmd())
 	root.AddCommand(buildSyncCmd())
 	return root

--- a/cmd/tx-load-test/setup/accounts_test.go
+++ b/cmd/tx-load-test/setup/accounts_test.go
@@ -52,6 +52,42 @@ func TestBuildAccountProvisionPlan(t *testing.T) {
 	}
 }
 
+func TestBuildAccountProvisionPlanPromotesExistingWithoutAppend(t *testing.T) {
+	feePayer, err := keypair.Random()
+	require.NoError(t, err)
+
+	existing := make([]*keypair.Full, 0, 10)
+	for idx := 1; idx <= 10; idx++ {
+		kp, err := state.DeriveKeypair(feePayer, idx)
+		require.NoError(t, err)
+		existing = append(existing, kp)
+	}
+
+	st := &state.State{
+		FeePayerKP:   feePayer,
+		AccountKPs:   existing,
+		SACHolderKPs: existing[:2],
+	}
+	cfg := config.DefaultConfig()
+	cfg.NumberOfAccounts = 10
+	cfg.Mode = config.ModeSoroswap
+	cfg.TargetRPS = 1
+	cfg.Duration = time.Second
+
+	plan, err := buildAccountProvisionPlan(cfg, st)
+	require.NoError(t, err)
+	require.Equal(t, 10, plan.existingCount)
+	require.Equal(t, 10, plan.targetCount)
+	require.Equal(t, 2, plan.existingHolders)
+	require.Equal(t, 10, plan.targetHolders)
+	require.Len(t, plan.promotedExistingKPs, 8)
+	require.Empty(t, plan.newKPs)
+	require.Empty(t, plan.holderNewKPs)
+	require.Empty(t, plan.passiveNewKPs)
+	require.Equal(t, existing[2].Address(), plan.promotedExistingKPs[0].Address())
+	require.Equal(t, existing[9].Address(), plan.promotedExistingKPs[7].Address())
+}
+
 func TestMinimumFeePayerBalanceUsesAccountDelta(t *testing.T) {
 	feePayer, err := keypair.Random()
 	require.NoError(t, err)

--- a/cmd/tx-load-test/setup/accounts_test.go
+++ b/cmd/tx-load-test/setup/accounts_test.go
@@ -52,6 +52,29 @@ func TestBuildAccountProvisionPlan(t *testing.T) {
 	}
 }
 
+func TestMinimumFeePayerBalanceUsesAccountDelta(t *testing.T) {
+	feePayer, err := keypair.Random()
+	require.NoError(t, err)
+
+	existing := make([]*keypair.Full, 0, 5)
+	for idx := 1; idx <= 5; idx++ {
+		kp, err := state.DeriveKeypair(feePayer, idx)
+		require.NoError(t, err)
+		existing = append(existing, kp)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.NumberOfAccounts = 5
+	cfg.BaseReserveXLM = 3
+
+	require.Equal(t, 115.0, minimumFeePayerBalanceXLM(cfg, nil))
+	require.Equal(t, 106.0, minimumFeePayerBalanceXLM(cfg, &state.State{AccountKPs: existing[:3]}))
+	require.Equal(t, 100.0, minimumFeePayerBalanceXLM(cfg, &state.State{AccountKPs: existing}))
+
+	cfg.NumberOfAccounts = 2
+	require.Equal(t, 100.0, minimumFeePayerBalanceXLM(cfg, &state.State{AccountKPs: existing}))
+}
+
 func TestPlanSACHolderRepairs(t *testing.T) {
 	issuer, err := keypair.Random()
 	require.NoError(t, err)

--- a/cmd/tx-load-test/setup/fee_payer.go
+++ b/cmd/tx-load-test/setup/fee_payer.go
@@ -115,7 +115,7 @@ func (feePayerStep) Run(ctx context.Context, logger *log.Entry, cfg config.Confi
 	if err != nil {
 		return fmt.Errorf("fee payer: read balance: %w", err)
 	}
-	minRequired := float64(cfg.NumberOfAccounts)*cfg.BaseReserveXLM + setupFeeBudgetXLM
+	minRequired := minimumFeePayerBalanceXLM(cfg, st)
 	for balance < minRequired {
 		if netInfo.FriendbotURL == "" {
 			return fmt.Errorf(
@@ -139,6 +139,15 @@ func (feePayerStep) Run(ctx context.Context, logger *log.Entry, cfg config.Confi
 	st.FeePayerKP = kp
 	st.NetworkPassphrase = cfg.NetworkPassphrase
 	return nil
+}
+
+func minimumFeePayerBalanceXLM(cfg config.Config, st *state.State) float64 {
+	existingAccounts := 0
+	if st != nil {
+		existingAccounts = len(st.AccountKPs)
+	}
+	accountsToCreate := max(0, cfg.NumberOfAccounts-existingAccounts)
+	return float64(accountsToCreate)*cfg.BaseReserveXLM + setupFeeBudgetXLM
 }
 
 // fundViaFriendbot sends a GET request to the friendbot URL with the target

--- a/cmd/tx-load-test/setup_cmd.go
+++ b/cmd/tx-load-test/setup_cmd.go
@@ -53,7 +53,7 @@ minted before the command exits.`,
 	cmd.Flags().String("soroswap-factory", "", "Soroswap factory contract ID (required on testnet/mainnet; optional on standalone/futurenet, where setup can auto-deploy it)")
 	cmd.Flags().String("soroswap-router", "", "Soroswap router contract ID (required on testnet/mainnet; optional on standalone/futurenet, where setup can auto-deploy it)")
 	cmd.Flags().Int("accounts", 5_000, "Number of participant accounts to create")
-	cmd.Flags().Float64("base-reserve-xlm", 3.0, "XLM to fund each account (covers reserves, holder trustlines, and fee headroom)")
+	cmd.Flags().Float64("base-reserve-xlm", 3.0, "XLM to fund each account (3.0 covers a 2.5 XLM three-trustline minimum plus 0.5 XLM headroom)")
 	cmd.Flags().Int64("liquidity-per-pool", 1_000_000, "Token units to deposit into each Soroswap pool")
 	return cmd
 }

--- a/cmd/tx-load-test/soroban/simulate.go
+++ b/cmd/tx-load-test/soroban/simulate.go
@@ -22,6 +22,13 @@ type SimulatedInvocation struct {
 	ResourceFee xdr.Int64
 	Footprint   xdr.LedgerFootprint
 	AuthEntries []xdr.SorobanAuthorizationEntry
+	// Ext carries the simulator's SorobanTransactionDataExt. When the simulator
+	// runs against an AutoRestoringSnapshotSource, V1 holds the read-write
+	// footprint indices that core must auto-restore inline at apply time. The
+	// extension MUST be reattached to the submitted SorobanTransactionData;
+	// dropping it causes apply to fail with invokeHostFunctionEntryArchived
+	// for entries the simulator already paid for via the inflated resource fee.
+	Ext xdr.SorobanTransactionDataExt
 }
 
 type RestoreProbeOptions struct {
@@ -37,6 +44,13 @@ type RestoreProbeResult struct {
 	ResourceFee         xdr.Int64
 	Simulation          SimulatedInvocation
 	HasSimulation       bool
+	// AutoRestoreKeys counts read-write footprint indices the simulator
+	// marked for inline auto-restoration via SorobanResourcesExtV0. A non-zero
+	// count means the corresponding ledger entries are archived and the
+	// invoking tx must carry SorobanTransactionDataExt.V1 for apply to
+	// auto-restore them; the legacy RestorePreamble is intentionally absent
+	// in this case.
+	AutoRestoreKeys int
 }
 
 func SimulateInvokeContract(
@@ -168,6 +182,17 @@ func RestoreInvokeContract(
 			PadSimulatedInvocation(&sim, options.PadFactor)
 			result.Simulation = sim
 			result.HasSimulation = true
+			// Protocol-23+ autorestore: when read-write entries are archived
+			// but not yet evicted, the simulator omits RestorePreamble and
+			// instead encodes the indices in SorobanResourcesExtV0. Surface
+			// that here so callers can distinguish a true noop from one that
+			// silently relies on autorestore at apply time.
+			if archived := sim.ArchivedSorobanEntries(); len(archived) > 0 {
+				result.RestoreNeeded = true
+				result.AutoRestoreKeys += len(archived)
+				result.ReadWriteKeys += len(archived)
+				result.ResourceFee += sim.ResourceFee
+			}
 			return result, nil
 		}
 
@@ -262,7 +287,17 @@ func parseSimulatedInvocation(simResp protocol.SimulateTransactionResponse) (Sim
 		ResourceFee: sorobanData.ResourceFee,
 		Footprint:   sorobanData.Resources.Footprint,
 		AuthEntries: authEntries,
+		Ext:         sorobanData.Ext,
 	}, nil
+}
+
+// ArchivedSorobanEntries returns the read-write footprint indices the
+// simulator marked for inline auto-restoration, or nil if none.
+func (s SimulatedInvocation) ArchivedSorobanEntries() []xdr.Uint32 {
+	if s.Ext.V != 1 || s.Ext.ResourceExt == nil {
+		return nil
+	}
+	return s.Ext.ResourceExt.ArchivedSorobanEntries
 }
 
 func PadSimulatedInvocation(sim *SimulatedInvocation, factor float64) {

--- a/cmd/tx-load-test/soroban/simulate.go
+++ b/cmd/tx-load-test/soroban/simulate.go
@@ -24,6 +24,21 @@ type SimulatedInvocation struct {
 	AuthEntries []xdr.SorobanAuthorizationEntry
 }
 
+type RestoreProbeOptions struct {
+	DryRun    bool
+	PadFactor float64
+}
+
+type RestoreProbeResult struct {
+	RestoreNeeded       bool
+	RestoreTransactions int
+	ReadOnlyKeys        int
+	ReadWriteKeys       int
+	ResourceFee         xdr.Int64
+	Simulation          SimulatedInvocation
+	HasSimulation       bool
+}
+
 func SimulateInvokeContract(
 	st *state.State,
 	txSourceKP *keypair.Full,
@@ -31,7 +46,10 @@ func SimulateInvokeContract(
 	invokeArgs xdr.InvokeContractArgs,
 	baseFee int64,
 ) (SimulatedInvocation, error) {
-	simResp, err := simulateInvokeContractResponse(st, txSourceKP, opSourceAddress, invokeArgs, baseFee)
+	ctx, cancel := context.WithTimeout(context.Background(), simulateInvokeTimeout)
+	defer cancel()
+
+	simResp, err := simulateInvokeContractResponse(ctx, st, txSourceKP, opSourceAddress, invokeArgs, baseFee)
 	if err != nil {
 		return SimulatedInvocation{}, err
 	}
@@ -44,13 +62,14 @@ func SimulateInvokeContract(
 }
 
 func simulateInvokeContractResponse(
+	ctx context.Context,
 	st *state.State,
 	txSourceKP *keypair.Full,
 	opSourceAddress string,
 	invokeArgs xdr.InvokeContractArgs,
 	baseFee int64,
 ) (protocol.SimulateTransactionResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), simulateInvokeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, simulateInvokeTimeout)
 	defer cancel()
 
 	op := txnbuild.InvokeHostFunction{
@@ -96,8 +115,9 @@ func SimulatePaddedInvokeContract(
 	baseFee int64,
 	padFactor float64,
 ) (SimulatedInvocation, error) {
+	ctx := context.Background()
 	for restoreAttempt := 0; restoreAttempt <= maxSimulationRestoreAttempts; restoreAttempt++ {
-		simResp, err := simulateInvokeContractResponse(st, txSourceKP, opSourceAddress, invokeArgs, baseFee)
+		simResp, err := simulateInvokeContractResponse(ctx, st, txSourceKP, opSourceAddress, invokeArgs, baseFee)
 		if err != nil {
 			return SimulatedInvocation{}, err
 		}
@@ -105,7 +125,7 @@ func SimulatePaddedInvokeContract(
 			if restoreAttempt == maxSimulationRestoreAttempts {
 				return SimulatedInvocation{}, fmt.Errorf("simulate: restore still required after %d attempts", restoreAttempt+1)
 			}
-			if err := submitSimulationRestore(st, txSourceKP, simResp.RestorePreamble); err != nil {
+			if err := submitSimulationRestore(ctx, st, txSourceKP, simResp.RestorePreamble); err != nil {
 				return SimulatedInvocation{}, fmt.Errorf("restore footprint: %w", err)
 			}
 			continue
@@ -122,7 +142,60 @@ func SimulatePaddedInvokeContract(
 	return SimulatedInvocation{}, fmt.Errorf("simulate: restoration attempts exhausted")
 }
 
-func submitSimulationRestore(st *state.State, fallbackSigner *keypair.Full, preamble *protocol.RestorePreamble) error {
+func RestoreInvokeContract(
+	ctx context.Context,
+	st *state.State,
+	txSourceKP *keypair.Full,
+	opSourceAddress string,
+	invokeArgs xdr.InvokeContractArgs,
+	baseFee int64,
+	options RestoreProbeOptions,
+) (RestoreProbeResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	var result RestoreProbeResult
+	for restoreAttempt := 0; restoreAttempt <= maxSimulationRestoreAttempts; restoreAttempt++ {
+		simResp, err := simulateInvokeContractResponse(ctx, st, txSourceKP, opSourceAddress, invokeArgs, baseFee)
+		if err != nil {
+			return result, err
+		}
+		if simResp.RestorePreamble == nil {
+			sim, err := parseSimulatedInvocation(simResp)
+			if err != nil {
+				return result, err
+			}
+			PadSimulatedInvocation(&sim, options.PadFactor)
+			result.Simulation = sim
+			result.HasSimulation = true
+			return result, nil
+		}
+
+		result.RestoreNeeded = true
+		sorobanData, err := restoreSorobanTransactionData(simResp.RestorePreamble)
+		if err != nil {
+			return result, err
+		}
+		result.ReadOnlyKeys += len(sorobanData.Resources.Footprint.ReadOnly)
+		result.ReadWriteKeys += len(sorobanData.Resources.Footprint.ReadWrite)
+		result.ResourceFee += sorobanData.ResourceFee
+
+		if options.DryRun {
+			return result, nil
+		}
+		if restoreAttempt == maxSimulationRestoreAttempts {
+			return result, fmt.Errorf("simulate: restore still required after %d attempts", restoreAttempt+1)
+		}
+		if err := submitSimulationRestore(ctx, st, txSourceKP, simResp.RestorePreamble); err != nil {
+			return result, fmt.Errorf("restore footprint: %w", err)
+		}
+		result.RestoreTransactions++
+	}
+
+	return result, fmt.Errorf("simulate: restoration attempts exhausted")
+}
+
+func submitSimulationRestore(ctx context.Context, st *state.State, fallbackSigner *keypair.Full, preamble *protocol.RestorePreamble) error {
 	sorobanData, err := restoreSorobanTransactionData(preamble)
 	if err != nil {
 		return err
@@ -137,7 +210,7 @@ func submitSimulationRestore(st *state.State, fallbackSigner *keypair.Full, prea
 	if st.NetworkPassphrase == "" {
 		return fmt.Errorf("missing network passphrase for restore transaction")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), simulateInvokeTimeout)
+	ctx, cancel := context.WithTimeout(ctx, simulateInvokeTimeout)
 	defer cancel()
 	logger := log.New().WithField("phase", "benchmark restore")
 	return state.SubmitAndWait(

--- a/cmd/tx-load-test/soroban/simulate_test.go
+++ b/cmd/tx-load-test/soroban/simulate_test.go
@@ -80,6 +80,58 @@ func TestPadSimulatedInvocation(t *testing.T) {
 	require.Equal(t, xdr.Uint32(110), sim.Resources.Instructions)
 }
 
+func TestParseSimulatedInvocationCarriesAutorestoreExt(t *testing.T) {
+	// Protocol-23+ autorestore: simulator returns SorobanTransactionData with
+	// ext.v1.archivedSorobanEntries listing read-write footprint indices
+	// that core must auto-restore inline at apply. The parser must capture
+	// the extension verbatim so the targeter can re-attach it to the
+	// submitted tx; dropping it forces apply to fail with
+	// invokeHostFunctionEntryArchived.
+	data := xdr.SorobanTransactionData{
+		Resources: xdr.SorobanResources{
+			Instructions:  10,
+			DiskReadBytes: 20,
+			WriteBytes:    30,
+		},
+		ResourceFee: 110_000_000, // realistic autorestore-inflated fee
+		Ext: xdr.SorobanTransactionDataExt{
+			V: 1,
+			ResourceExt: &xdr.SorobanResourcesExtV0{
+				ArchivedSorobanEntries: []xdr.Uint32{0, 2},
+			},
+		},
+	}
+	encoded, err := xdr.MarshalBase64(data)
+	require.NoError(t, err)
+
+	sim, err := parseSimulatedInvocation(protocol.SimulateTransactionResponse{
+		TransactionDataXDR: encoded,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), int32(sim.Ext.V))
+	require.NotNil(t, sim.Ext.ResourceExt)
+	require.Equal(t,
+		[]xdr.Uint32{0, 2},
+		sim.Ext.ResourceExt.ArchivedSorobanEntries,
+	)
+	require.Equal(t, []xdr.Uint32{0, 2}, sim.ArchivedSorobanEntries())
+}
+
+func TestParseSimulatedInvocationDefaultsToV0WhenNoAutorestore(t *testing.T) {
+	data := xdr.SorobanTransactionData{
+		Resources:   xdr.SorobanResources{Instructions: 1},
+		ResourceFee: 100,
+	}
+	encoded, err := xdr.MarshalBase64(data)
+	require.NoError(t, err)
+	sim, err := parseSimulatedInvocation(protocol.SimulateTransactionResponse{
+		TransactionDataXDR: encoded,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(0), int32(sim.Ext.V))
+	require.Nil(t, sim.ArchivedSorobanEntries())
+}
+
 func TestRestoreSorobanTransactionDataAppliesMinResourceFee(t *testing.T) {
 	data := xdr.SorobanTransactionData{
 		Resources:   xdr.SorobanResources{Instructions: 10},

--- a/cmd/tx-load-test/state/benchmark_accounts.go
+++ b/cmd/tx-load-test/state/benchmark_accounts.go
@@ -16,11 +16,11 @@ const (
 	SimplePaymentOpsPerTransaction = 1
 	// RecommendedSourceReuseLedgers is the target minimum source-account reuse
 	// interval used by the recommended pool-size formula.
-	RecommendedSourceReuseLedgers = 2
+	RecommendedSourceReuseLedgers = 3
 	// SourceAccountRunBudget is the maximum number of transactions one source
 	// account should ideally submit over a single benchmark run before we size a
 	// larger source-account pool. With a 5 second ledger cadence and a
-	// 2-ledger preferred reuse gap, a 5 minute run naturally reuses each source
+	// 3-ledger preferred reuse gap, a 5 minute run naturally reuses each source
 	// account about 30 times, so runs longer than 5 minutes are where the
 	// duration-based budget starts growing the recommended pool size.
 	SourceAccountRunBudget = 30

--- a/cmd/tx-load-test/state/benchmark_accounts_test.go
+++ b/cmd/tx-load-test/state/benchmark_accounts_test.go
@@ -16,16 +16,16 @@ func TestAccountSizingFormula(t *testing.T) {
 		Duration:   2 * time.Minute,
 	}
 
-	require.Equal(t, 4000, AnySourceAccountCount(cfg))
-	require.Equal(t, 2000, SorobanSourceAccountCount(cfg))
+	require.Equal(t, 6000, AnySourceAccountCount(cfg))
+	require.Equal(t, 3000, SorobanSourceAccountCount(cfg))
 	require.Equal(t, 200, SimplePaymentTransactionRate(cfg))
-	require.Equal(t, 2000, SimplePaymentSourceAccountCount(cfg))
+	require.Equal(t, 3000, SimplePaymentSourceAccountCount(cfg))
 	require.Equal(t, 2, HolderAccountCount(cfg))
 
 	cfg.Mode = config.ModeSoroswap
-	require.Equal(t, 2000, HolderAccountCount(cfg))
-	require.Equal(t, 2000, BenchmarkSupersetHolderAccountCount(cfg))
-	require.Equal(t, 2000, RecommendedBenchmarkSupersetHolderAccountCount(cfg, 5000))
+	require.Equal(t, 3000, HolderAccountCount(cfg))
+	require.Equal(t, 3000, BenchmarkSupersetHolderAccountCount(cfg))
+	require.Equal(t, 3000, RecommendedBenchmarkSupersetHolderAccountCount(cfg, 5000))
 	require.Equal(t, 500, RecommendedBenchmarkSupersetHolderAccountCount(cfg, 500))
 }
 
@@ -37,8 +37,8 @@ func TestAccountSizingFormulaFiveMinuteNormal(t *testing.T) {
 		Duration:   5 * time.Minute,
 	}
 
-	require.Equal(t, 2650, AnySourceAccountCount(cfg))
-	require.Equal(t, 650, SorobanSourceAccountCount(cfg))
+	require.Equal(t, 3975, AnySourceAccountCount(cfg))
+	require.Equal(t, 975, SorobanSourceAccountCount(cfg))
 	require.Equal(t, 200, SimplePaymentTransactionRate(cfg))
-	require.Equal(t, 2000, SimplePaymentSourceAccountCount(cfg))
+	require.Equal(t, 3000, SimplePaymentSourceAccountCount(cfg))
 }

--- a/cmd/tx-load-test/state/loader.go
+++ b/cmd/tx-load-test/state/loader.go
@@ -11,6 +11,7 @@ type RuntimePhase string
 
 const (
 	RuntimePhaseBench    RuntimePhase = "bench"
+	RuntimePhaseRestore  RuntimePhase = "restore"
 	RuntimePhaseTeardown RuntimePhase = "teardown"
 	RuntimePhaseSync     RuntimePhase = "sync"
 )
@@ -161,6 +162,8 @@ func validateRuntimeAccountsExist(
 func runtimePhaseHint(phase RuntimePhase) string {
 	switch phase {
 	case RuntimePhaseBench:
+		return "  -- run 'setup' first"
+	case RuntimePhaseRestore:
 		return "  -- run 'setup' first"
 	case RuntimePhaseTeardown:
 		return "  -- nothing to tear down"

--- a/cmd/tx-load-test/teardown/helpers.go
+++ b/cmd/tx-load-test/teardown/helpers.go
@@ -14,8 +14,15 @@ import (
 )
 
 func existingCleanupAccounts(ctx context.Context, logger *log.Entry, st *state.State, warnOnLookupError bool) []*keypair.Full {
+	return filterExistingAccounts(ctx, logger, st, st.AccountKPs, warnOnLookupError)
+}
+
+// filterExistingAccounts returns the subset of kps that currently exist
+// on-chain. It is used both for the full pool and for a tail slice in a
+// partial teardown.
+func filterExistingAccounts(ctx context.Context, logger *log.Entry, st *state.State, kps []*keypair.Full, warnOnLookupError bool) []*keypair.Full {
 	var toMerge []*keypair.Full
-	for _, kp := range st.AccountKPs {
+	for _, kp := range kps {
 		if kp == nil {
 			continue
 		}
@@ -31,6 +38,33 @@ func existingCleanupAccounts(ctx context.Context, logger *log.Entry, st *state.S
 		}
 	}
 	return toMerge
+}
+
+// minSafeKeep returns the smallest --keep value that does not merge any
+// benchmark holder account. Holders are the trustlined/token-funded subset
+// (in practice a prefix of the pool); a keep below this would shrink the
+// holder set and break benchmark modes. Membership-based so it is correct
+// regardless of ordering.
+func minSafeKeep(st *state.State) int {
+	if len(st.SACHolderKPs) == 0 {
+		return 0
+	}
+	holders := make(map[string]struct{}, len(st.SACHolderKPs))
+	for _, kp := range st.SACHolderKPs {
+		if kp != nil {
+			holders[kp.Address()] = struct{}{}
+		}
+	}
+	safe := 0
+	for i, kp := range st.AccountKPs {
+		if kp == nil {
+			continue
+		}
+		if _, ok := holders[kp.Address()]; ok {
+			safe = i + 1 // must retain through this holder's position
+		}
+	}
+	return safe
 }
 
 func cleanupBatches(accountKPs []*keypair.Full, batchSize int) [][]*keypair.Full {

--- a/cmd/tx-load-test/teardown/teardown.go
+++ b/cmd/tx-load-test/teardown/teardown.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/stellar/go-stellar-sdk/keypair"
 	"github.com/stellar/go-stellar-sdk/support/log"
 
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
@@ -25,15 +26,27 @@ const mergeBatchSize = 12
 // account count.
 const maxCleanupTimeout = 10 * time.Minute
 
-// Teardown merges every participant account back into the fee-payer account,
-// recovering all reserved XLM. On full success it deletes the state file.
-// On partial success it updates the state file to reflect remaining accounts
-// and logs a suggestion to re-run teardown.
-func Teardown(ctx context.Context, logger *log.Entry, cfg config.Config, st *state.State, stateFile string) error {
+// Teardown merges participant accounts back into the fee-payer account,
+// recovering reserved XLM.
+//
+// When keep <= 0 it is a full teardown: every participant account is merged
+// and the state file is deleted on full success; on partial failure the file
+// is updated with the remaining accounts.
+//
+// When keep > 0 it is a partial teardown: only the tail of the pool
+// (AccountKPs[keep:]) is merged, the first keep accounts are retained, and the
+// state file is always kept and updated. force allows merging into the
+// benchmark holder subset (which also shrinks it); without it, a keep that
+// would merge holder accounts is refused.
+func Teardown(ctx context.Context, logger *log.Entry, cfg config.Config, st *state.State, stateFile string, keep int, force bool) error {
 	logger = logger.WithField("phase", "teardown")
 
 	if !cleanupStateReady(logger, st) {
 		return nil
+	}
+
+	if keep > 0 {
+		return partialTeardown(ctx, logger, cfg, st, stateFile, keep, force)
 	}
 
 	toMerge := existingCleanupAccounts(ctx, logger, st, true)
@@ -49,6 +62,49 @@ func Teardown(ctx context.Context, logger *log.Entry, cfg config.Config, st *sta
 	}
 
 	return finalizeTeardown(logger, st, stateFile)
+}
+
+// partialTeardown merges the tail of the pool (everything after the first
+// keep accounts) back into the fee payer, retaining the front and always
+// keeping the state file.
+func partialTeardown(ctx context.Context, logger *log.Entry, cfg config.Config, st *state.State, stateFile string, keep int, force bool) error {
+	pool := len(st.AccountKPs)
+	if keep >= pool {
+		logger.Infof("pool has %d accounts, at or below keep=%d -- nothing to merge", pool, keep)
+		return nil
+	}
+
+	if safe := minSafeKeep(st); keep < safe && !force {
+		return fmt.Errorf(
+			"keep=%d would merge benchmark holder accounts -- keep at least %d to preserve the holder subset, or pass --force to merge into it (shrinks the holder set)",
+			keep, safe)
+	}
+
+	tail := st.AccountKPs[keep:]
+
+	// Tail accounts that no longer exist on-chain are already gone; drop them
+	// from state so they don't count against the keep target or trigger a false
+	// "incomplete" result. Persist that pruning before merging.
+	toMerge := filterExistingAccounts(ctx, logger, st, tail, true)
+	if gone := accountsNotIn(tail, toMerge); len(gone) > 0 {
+		removeMergedAccounts(st, gone)
+		if err := saveStateSnapshot(cfg, st, stateFile); err != nil {
+			return fmt.Errorf("save state after pruning %d absent tail accounts: %w", len(gone), err)
+		}
+		logger.Infof("pruned %d tail accounts already absent on-chain", len(gone))
+	}
+
+	if len(toMerge) == 0 {
+		logger.Infof("no tail accounts to merge; pool now %d accounts (kept first %d)", len(st.AccountKPs), keep)
+		return nil
+	}
+
+	logger.Infof("partial teardown: merging %d tail accounts, keeping first %d", len(toMerge), keep)
+	if err := runCleanupBatches(ctx, logger, cfg, st, stateFile, toMerge); err != nil {
+		return err
+	}
+
+	return finalizePartialTeardown(logger, cfg, st, stateFile, keep)
 }
 
 // BestEffortCleanup is called on interrupt / panic during setup. It attempts
@@ -101,6 +157,48 @@ func finalizeTeardown(logger *log.Entry, st *state.State, stateFile string) erro
 	logger.Info("all accounts merged")
 	deleteStateFile(logger, stateFile)
 	return nil
+}
+
+func finalizePartialTeardown(logger *log.Entry, cfg config.Config, st *state.State, stateFile string, keep int) error {
+	// runCleanupBatches snapshots after each batch; snapshot once more so the
+	// final state is durable even if the last batch removed nothing.
+	if err := saveStateSnapshot(cfg, st, stateFile); err != nil {
+		return fmt.Errorf("save final state: %w", err)
+	}
+
+	remaining := len(st.AccountKPs)
+	if remaining > keep {
+		logger.Warnf("%d accounts remain but target was %d -- %d tail accounts could not be merged; re-run with the same --keep to finish",
+			remaining, keep, remaining-keep)
+		return fmt.Errorf("partial teardown incomplete: %d accounts remain, target %d", remaining, keep)
+	}
+
+	logger.Infof("partial teardown complete: pool now %d accounts (kept first %d); state file %s retained", remaining, keep, stateFile)
+	if holders := len(st.SACHolderKPs); holders > 0 && remaining < holders {
+		logger.Warnf("remaining pool %d is below the holder count %d -- benchmark capability may be reduced", remaining, holders)
+	}
+	return nil
+}
+
+// accountsNotIn returns the members of all that are absent from subset,
+// compared by address.
+func accountsNotIn(all, subset []*keypair.Full) []*keypair.Full {
+	present := make(map[string]struct{}, len(subset))
+	for _, kp := range subset {
+		if kp != nil {
+			present[kp.Address()] = struct{}{}
+		}
+	}
+	var missing []*keypair.Full
+	for _, kp := range all {
+		if kp == nil {
+			continue
+		}
+		if _, ok := present[kp.Address()]; !ok {
+			missing = append(missing, kp)
+		}
+	}
+	return missing
 }
 
 func finalizeBestEffortCleanup(logger *log.Entry, st *state.State, stateFile string) {

--- a/cmd/tx-load-test/teardown/teardown_test.go
+++ b/cmd/tx-load-test/teardown/teardown_test.go
@@ -18,6 +18,42 @@ func TestCleanupBatchesSplitsInput(t *testing.T) {
 	require.Len(t, batches[2], 1)
 }
 
+func TestMinSafeKeepIsPositionPastLastHolder(t *testing.T) {
+	kps := make([]*keypair.Full, 6)
+	for i := range kps {
+		kp, err := keypair.Random()
+		require.NoError(t, err)
+		kps[i] = kp
+	}
+
+	// Holders are the first 3 (the usual prefix) -> safe keep is 3.
+	st := &state.State{AccountKPs: kps, SACHolderKPs: kps[:3]}
+	require.Equal(t, 3, minSafeKeep(st))
+
+	// No holders -> any keep is safe.
+	require.Equal(t, 0, minSafeKeep(&state.State{AccountKPs: kps}))
+
+	// A holder sitting at position 4 (non-prefix) forces safe keep to 5,
+	// proving the check is membership/position based, not a count.
+	st2 := &state.State{AccountKPs: kps, SACHolderKPs: []*keypair.Full{kps[0], kps[4]}}
+	require.Equal(t, 5, minSafeKeep(st2))
+}
+
+func TestAccountsNotInReturnsComplementByAddress(t *testing.T) {
+	kps := make([]*keypair.Full, 4)
+	for i := range kps {
+		kp, err := keypair.Random()
+		require.NoError(t, err)
+		kps[i] = kp
+	}
+	missing := accountsNotIn(kps, []*keypair.Full{kps[1], kps[3]})
+	require.Equal(t, []string{kps[0].Address(), kps[2].Address()},
+		[]string{missing[0].Address(), missing[1].Address()})
+
+	require.Empty(t, accountsNotIn(kps, kps))
+	require.Len(t, accountsNotIn(kps, nil), 4)
+}
+
 func TestRemoveMergedAccountsPrunesParticipantsAndHolders(t *testing.T) {
 	kp1, err := keypair.Random()
 	require.NoError(t, err)

--- a/cmd/tx-load-test/teardown_cmd.go
+++ b/cmd/tx-load-test/teardown_cmd.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
@@ -17,7 +19,13 @@ account back into the fee-payer account (recovering all reserved XLM), and
 deletes the state file on success.
 
 If teardown is interrupted or partially fails, the state file is updated to
-reflect only the remaining accounts so a subsequent teardown can finish the job.`,
+reflect only the remaining accounts so a subsequent teardown can finish the job.
+
+Use --keep N for a partial teardown: only the tail of the pool is merged, the
+first N accounts are retained, and the state file is always kept and updated.
+This reclaims XLM from unneeded accounts without dismantling the pool. By
+default a --keep that would merge benchmark holder accounts is refused; pass
+--force to merge into the holder subset (which shrinks it).`,
 		RunE: runTeardown,
 	}
 
@@ -25,6 +33,8 @@ reflect only the remaining accounts so a subsequent teardown can finish the job.
 	cmd.Flags().String("log-level", "info", "Log verbosity: debug | info | warn | error")
 	cmd.Flags().String("rpc-url", "", "Override the RPC URL stored in the state JSON file")
 	cmd.Flags().String("state-file", state.DefaultStateFile, "Path to the state JSON file")
+	cmd.Flags().Int("keep", 0, "Partial teardown: retain the first N pool accounts and merge the rest from the end (0 = full teardown)")
+	cmd.Flags().Bool("force", false, "Allow --keep to merge benchmark holder accounts (shrinks the holder subset)")
 	return cmd
 }
 
@@ -39,6 +49,18 @@ func runTeardown(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	keep, err := cmd.Flags().GetInt("keep")
+	if err != nil {
+		return err
+	}
+	if keep < 0 {
+		return fmt.Errorf("--keep must be >= 0")
+	}
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
 	cfg := config.DefaultConfig()
 	cfg.RPCURL = loaded.RPCURL
 	cfg.NetworkPassphrase = loaded.Persisted.NetworkPassphrase
@@ -47,6 +69,10 @@ func runTeardown(cmd *cobra.Command, _ []string) error {
 	ctx, cancel := signalCommandContext(cmd, logger, true)
 	defer cancel()
 
-	logger.Infof("loaded state from %s (%d accounts)", stateFile, cfg.NumberOfAccounts)
-	return teardown.Teardown(ctx, logger, cfg, loaded.Live, stateFile)
+	if keep > 0 {
+		logger.Infof("loaded state from %s (%d accounts); partial teardown keeping first %d", stateFile, cfg.NumberOfAccounts, keep)
+	} else {
+		logger.Infof("loaded state from %s (%d accounts)", stateFile, cfg.NumberOfAccounts)
+	}
+	return teardown.Teardown(ctx, logger, cfg, loaded.Live, stateFile, keep, force)
 }

--- a/cmd/tx-load-test/tools/derive-oz-accounts/main.go
+++ b/cmd/tx-load-test/tools/derive-oz-accounts/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/stellar/go-stellar-sdk/keypair"
+	"github.com/stellar/go-stellar-sdk/strkey"
+
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
+)
+
+type persistedState struct {
+	FeePayerHash    string   `json:"fee_payer_hash"`
+	AccountIndices  []uint32 `json:"account_indices"`
+	OZTokenContract string   `json:"oz_token_contract"`
+	CleanedUp       bool     `json:"cleaned_up"`
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: FEE_PAYER=S... %s <public-key[,public-key...]> <state-file>\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	if err := run(os.Getenv("FEE_PAYER"), flag.Arg(0), flag.Arg(1)); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(seed string, publicKeysCSV string, stateFile string) error {
+	seed = strings.TrimSpace(seed)
+	if seed == "" {
+		return fmt.Errorf("fee-payer seed is required: set FEE_PAYER")
+	}
+
+	publicKeys, err := parsePublicKeys(publicKeysCSV)
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(stateFile)
+	if err != nil {
+		return fmt.Errorf("read state file %q: %w", stateFile, err)
+	}
+
+	var st persistedState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return fmt.Errorf("parse state file %q: %w", stateFile, err)
+	}
+	if st.CleanedUp {
+		return fmt.Errorf("state file is marked cleaned_up=true")
+	}
+	if st.OZTokenContract == "" {
+		return fmt.Errorf("state file has no oz_token_contract")
+	}
+	if len(st.AccountIndices) == 0 {
+		return fmt.Errorf("state file has no account_indices")
+	}
+	if got := state.HashSeed(seed); got != st.FeePayerHash {
+		return fmt.Errorf("provided seed does not match fee_payer_hash in %s", stateFile)
+	}
+
+	feePayer, err := keypair.ParseFull(seed)
+	if err != nil {
+		return fmt.Errorf("parse fee-payer seed: %w", err)
+	}
+
+	seedsByPublicKey := make(map[string]string, len(st.AccountIndices))
+	for _, index := range st.AccountIndices {
+		kp, err := state.DeriveKeypair(feePayer, int(index))
+		if err != nil {
+			return fmt.Errorf("derive account index %d: %w", index, err)
+		}
+		seedsByPublicKey[kp.Address()] = kp.Seed()
+	}
+
+	missing := make([]string, 0)
+	for _, publicKey := range publicKeys {
+		if _, ok := seedsByPublicKey[publicKey]; !ok {
+			missing = append(missing, publicKey)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("public key(s) are not part of account_indices in %s: %s", stateFile, strings.Join(missing, ","))
+	}
+
+	for _, publicKey := range publicKeys {
+		fmt.Printf("%s: %s\n", publicKey, seedsByPublicKey[publicKey])
+	}
+	return nil
+}
+
+func parsePublicKeys(value string) ([]string, error) {
+	parts := strings.Split(value, ",")
+	publicKeys := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		publicKey := strings.TrimSpace(part)
+		if publicKey == "" {
+			continue
+		}
+		if _, err := strkey.Decode(strkey.VersionByteAccountID, publicKey); err != nil {
+			return nil, fmt.Errorf("invalid public key %q: %w", publicKey, err)
+		}
+		if _, ok := seen[publicKey]; ok {
+			continue
+		}
+		seen[publicKey] = struct{}{}
+		publicKeys = append(publicKeys, publicKey)
+	}
+	if len(publicKeys) == 0 {
+		return nil, fmt.Errorf("at least one comma-separated public key is required")
+	}
+	return publicKeys, nil
+}


### PR DESCRIPTION
## Summary

Hardens `tx-load-test` for sustained high-RPS Soroban load, adds autorestore, and adds partial-teardown tooling.

## State restoration (new)
- New `restore` subcommand to prehydrate archived contract state before a run (per-workload, with `--dry-run`/`--verify`).
- Handles both legacy `RestorePreamble` and autorestore; preserves and re-attaches `SorobanTransactionDataExt` archive indices to SAC/OZ/soroswap envelopes.

## Throughput under load
- **Jittered per-tx fees** (`[10k,100k]` stroops vs. fixed 200) to reduce `txINSUFFICIENT_FEE` by avoiding surge-pricing fee ties.
- **`tx_bad_seq` routes to chain-state recovery** instead of retrying a stale sequence forever.
- **Parallel sequence prehydration** via batched `getLedgerEntries` (200 keys, 16 concurrent) replacing serial `LoadAccount`.
- Account re-use gap 2 → 3; setup promotes existing accounts instead of appending.

## Polling & latency
- Reworked polling into a single fair-priority scheduler with batched `GetTransactions`.
- First poll targets the predicted next-ledger window instead of an immediate guaranteed-miss; failed fetches requeue with backoff to a per-tx deadline.
- **Ledger-aware re-poll gating**: defers re-polls until the network ledger advances past the last-observed sequence (status only changes at ledger close), with a background latest-ledger ticker to keep the clock fresh during the drain tail.
- Tighter timeouts (poll 35s → 25s, tx 25s → 20s, 5s/attempt); `submittedAt` anchored to PENDING arrival.

## Robustness & teardown
- Parallel account recovery (32 workers) to avoid one slow `LoadAccount` stalling the pool.
- Prioritized diagnostics (error → call → other); metrics moved under `metrics/`.
- **Partial teardown via `--keep N`**: merges only the account tail beyond N, keeps holder accounts unless `--force`, prunes already-deleted accounts, and updates the state file in place.
