### PR TITLE
Facilitate automatic runninng of load testing tool

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the build context small, fast, and free of secrets/outputs.
+
+.git
+.gitignore
+.github
+*.md
+Dockerfile
+.dockerignore
+
+# Never bake state files (they carry the fee-payer hash + topology), seeds, or
+# run outputs into the image.
+state*.json
+*.ndjson
+debug*.ndjson
+traces/
+metrics/
+results-*/
+*.log
+*.png
+
+# Prebuilt binaries that may be lying around the repo root.
+tx-load-test
+pool-xlm
+parser
+
+# Heavy contract source/build trees. Keep only the flat runtime Wasm artifacts
+# the image actually copies.
+contracts/*
+!contracts/*.wasm

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,90 @@
+# Builds the tx-load-test container image and pushes it to the internal ECR
+# registry via stellar/actions/sdf-ecr-login (OIDC -- no long-lived AWS
+# secrets; the action's IAM policy only allows pushes from this repository's
+# workflows).
+#
+# Tags pushed:
+#   <registry>/tx-load-test:latest        -- tracks the default branch
+#   <registry>/tx-load-test:sha-<short>   -- immutable, for pinning in k8s
+#
+# The weekly CronJob should pin the sha- tag, not :latest, so a run is never
+# silently retargeted by a new push.
+name: Build & push TPS tool image
+
+on:
+  pull_request: 
+    branches: [load-tester]
+  push:
+    branches: [main, load-tester]
+    # Only rebuild when something that reaches the image changes. The binary
+    # pulls from cmd/tx-load-test/** and internal/** (run engine); the image
+    # also carries the flat contract Wasm artifacts.
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - go.mod
+      - go.sum
+      - cmd/tx-load-test/**
+      - internal/**
+      - contracts/*.wasm
+      - .github/workflows/push-image.yml
+  workflow_dispatch: {}
+
+# One image push at a time; a superseded build of the same ref is cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write # OIDC token for sdf-ecr-login
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to ECR
+        id: ecr
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Compute image tags
+        id: meta
+        run: |
+          registry='${{ steps.ecr.outputs.ecr-registry }}'
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          echo "image=${registry}/tx-load-test" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=sha-${short_sha}" >> "$GITHUB_OUTPUT"
+
+      - name: Build image
+        run: |
+          docker build \
+            --tag '${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}' \
+            --tag '${{ steps.meta.outputs.image }}:latest' \
+            .
+
+      # Smoke-test the scratch image actually executes before publishing it.
+      - name: Smoke test
+        run: |
+          docker run --rm '${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}' --help
+          docker run --rm '${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}' bench --help > /dev/null
+
+      # ecr-push (installed by sdf-ecr-login) replaces docker push: it creates
+      # the repository on first use (tagged with this GitHub repo for the IAM
+      # push policy) and then pushes.
+      - name: Push image
+        run: |
+          ecr-push '${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}'
+          ecr-push '${{ steps.meta.outputs.image }}:latest'
+
+      - name: Summary
+        run: |
+          {
+            echo "### tx-load-test image pushed"
+            echo '```'
+            echo '${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_tag }}'
+            echo '${{ steps.meta.outputs.image }}:latest'
+            echo '```'
+            echo "Pin the sha tag in the k8s CronJob."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -4,8 +4,8 @@
 # workflows).
 #
 # Tags pushed:
-#   <registry>/tx-load-test:latest        -- tracks the default branch
-#   <registry>/tx-load-test:sha-<short>   -- immutable, for pinning in k8s
+#   <registry>/dev/tx-load-test:latest        -- tracks the default branch
+#   <registry>/dev/tx-load-test:sha-<short>   -- immutable, for pinning in k8s
 #
 # The weekly CronJob should pin the sha- tag, not :latest, so a run is never
 # silently retargeted by a new push.
@@ -54,7 +54,9 @@ jobs:
         run: |
           registry='${{ steps.ecr.outputs.ecr-registry }}'
           short_sha="$(git rev-parse --short=12 HEAD)"
-          echo "image=${registry}/tx-load-test" >> "$GITHUB_OUTPUT"
+          # The dev/ namespace is required: ecr-push only auto-creates (and
+          # the push role only allows) repositories under dev/, stg/, prd/.
+          echo "image=${registry}/dev/tx-load-test" >> "$GITHUB_OUTPUT"
           echo "sha_tag=sha-${short_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Build image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the tx-load-test CLI.
+#
+# The binary is fully static (CGO disabled), so the final image is FROM scratch:
+# just the binary, the TLS root certificates, and the flat Wasm artifacts that
+# `setup` needs. bench / teardown / sync do not read the Wasm files.
+
+# ---- build stage ----
+FROM golang:1.25-bookworm AS build
+WORKDIR /src
+
+# Download modules first so this layer is cached across source-only changes.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+# Build a fully static binary. CGO_ENABLED=0 is what makes `scratch` viable;
+# -trimpath + -s -w keep it lean and reproducible.
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux \
+    go build -trimpath -ldflags="-s -w" -o /out/tx-load-test ./cmd/tx-load-test
+
+# ---- final stage ----
+FROM scratch
+
+# TLS roots, so HTTPS RPC endpoints and friendbot work. Harmless if you only
+# ever talk to a plain-HTTP RPC.
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+COPY --from=build /out/tx-load-test /usr/local/bin/tx-load-test
+
+# Flat Wasm artifacts, resolved by `setup` relative to the working directory as
+# "contracts/<name>.wasm". Only needed for `setup` on standalone/futurenet;
+# bench / teardown / sync ignore them.
+COPY contracts/oz_token.wasm \
+     contracts/soroswap_pair.wasm \
+     contracts/soroswap_factory.wasm \
+     contracts/soroswap_router.wasm \
+     /contracts/
+
+WORKDIR /
+
+# Run unprivileged. 65532 is the conventional "nonroot" uid/gid (matches
+# distroless), so Kubernetes runAsNonRoot: true is satisfied without extra
+# config. All writable output (metrics, trace) must go to a mounted volume;
+# the root filesystem can be read-only.
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/tx-load-test"]

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -171,6 +171,7 @@ Before the benchmark starts, the tool queries the chosen RPC endpoint (either `-
 | `--account-preflight-sample` | `10` | Number of participant accounts to sample during runtime preflight |
 | `--trace-file` | *(disabled)* | Optional NDJSON file that captures every benchmark submit and poll request/response |
 | `--metrics-file` | `metrics/tx-load-test-metrics-<timestamp>-<mode>.ndjson` | Optional flattened benchmark metrics file path |
+| `--metrics-gcs-url` | *(disabled)* | Optional `gs://bucket/prefix/` destination; the metrics file is uploaded there after the run. A trailing slash appends the local filename (unique per run); auth uses Application Default Credentials |
 | `--log-level` | `info` | `debug`, `info`, `warn`, `error` |
 
 **Mode guide:**

--- a/cmd/tx-load-test/README.md
+++ b/cmd/tx-load-test/README.md
@@ -274,8 +274,8 @@ Removes entries for accounts that no longer exist on-chain, useful after a netwo
   "rpc_url": "https://soroban-testnet.stellar.org",
   "network_passphrase": "Test SDF Network ; September 2015",
   "fee_payer_hash": "5d7a...hex-sha256...",
-  "account_indices": [1, 2, 3],
-  "sac_holder_indices": [1, 2, 3],
+  "account_ranges": ["1-4500"],
+  "sac_holder_ranges": ["1-900"],
   "assets": ["BLTA", "BLTB", "BLTC"],
   "sacs": ["C...", "C...", "C..."],
   "soroswap_factory_contract": "C...",
@@ -285,5 +285,7 @@ Removes entries for accounts that no longer exist on-chain, useful after a netwo
   "cleaned_up": false
 }
 ```
+
+Participant accounts are recorded as derivation-index **ranges**: each entry is a single index (`"5"`) or an inclusive contiguous run (`"1-4500"`), sorted ascending and non-overlapping. A freshly set-up pool is a single range; `sync` pruning or a partially failed teardown batch simply produce more ranges (`["1-3999", "4100-4500"]`). This keeps the file a few hundred bytes regardless of pool size — small enough to inline in a Kubernetes ConfigMap. Legacy files using flat `account_indices` / `sac_holder_indices` arrays are still read transparently and are upgraded to the range form on the next save.
 
 The file is written atomically (write to `.tmp`, then rename) to avoid corruption from interrupted writes. No raw seeds are stored on disk. The recorded `rpc_url` and `network_passphrase` are treated as part of the state identity and are validated before the state is reused.

--- a/cmd/tx-load-test/bench_cmd.go
+++ b/cmd/tx-load-test/bench_cmd.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	supportlog "github.com/stellar/go-stellar-sdk/support/log"
+
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/benchmark"
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/gcs"
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
 )
 
@@ -54,6 +59,7 @@ Run bench as many times as needed.`,
 	cmd.Flags().Int("classic-rps", config.DefaultClassicRPS, "Steady-state simple-payment transactions per second after ramp-up (1 payment op per tx)")
 	cmd.Flags().String("trace-file", "", "Optional newline-delimited JSON file that captures every benchmark submit and poll request/response")
 	cmd.Flags().String("metrics-file", "", "Optional NDJSON file for benchmark metrics (default: metrics/ timestamped filename containing the selected mode)")
+	cmd.Flags().String("metrics-gcs-url", "", "Optional gs://bucket/prefix/ destination; the metrics file is uploaded there after the run (auth via Application Default Credentials)")
 	return cmd
 }
 
@@ -91,6 +97,10 @@ func runBench(cmd *cobra.Command, _ []string) error {
 	if cfg.MetricsFile == "" {
 		cfg.MetricsFile = benchmark.DefaultMetricsFileName(cfg.Mode, time.Now())
 	}
+	metricsGCSURL, err := cmd.Flags().GetString("metrics-gcs-url")
+	if err != nil {
+		return err
+	}
 	if err = benchmark.ValidateCLIConfig(cfg); err != nil {
 		return err
 	}
@@ -127,5 +137,32 @@ func runBench(cmd *cobra.Command, _ []string) error {
 	if err = benchmark.Run(ctx, logger, cfg, loaded.Live, httpClient); err != nil {
 		logger.WithError(err).Error("benchmark failed")
 	}
+
+	if uploadErr := uploadMetricsIfRequested(logger, metricsGCSURL, cfg.MetricsFile); uploadErr != nil && err == nil {
+		// The bench itself succeeded; surface the upload failure as the run
+		// error so automated runs (k8s Jobs) alert instead of silently losing
+		// the metrics when the pod's volume is reclaimed.
+		err = uploadErr
+	}
 	return err
+}
+
+// uploadMetricsIfRequested ships the metrics file to GCS when a destination
+// was given. It runs on a fresh context (not the possibly-cancelled run
+// context) so an interrupted bench still ships whatever was written; the
+// uploader applies its own timeout.
+func uploadMetricsIfRequested(logger *supportlog.Entry, gcsURL, metricsFile string) error {
+	if gcsURL == "" {
+		return nil
+	}
+	if _, err := os.Stat(metricsFile); err != nil {
+		return fmt.Errorf("metrics file %s not available for GCS upload: %w", metricsFile, err)
+	}
+	objectURL, err := gcs.Upload(context.Background(), gcsURL, metricsFile)
+	if err != nil {
+		logger.WithError(err).Error("metrics GCS upload failed")
+		return fmt.Errorf("upload metrics to GCS: %w", err)
+	}
+	logger.Infof("benchmark metrics uploaded to %s", objectURL)
+	return nil
 }

--- a/cmd/tx-load-test/benchmark/sac_transfer.go
+++ b/cmd/tx-load-test/benchmark/sac_transfer.go
@@ -19,32 +19,37 @@ import (
 // benchmarkBaseFeeMin and benchmarkBaseFeeMax bound the per-op inclusion fee
 // (in stroops) randomly chosen for each submitted benchmark transaction.
 //
-// Two reasons we sample per-tx instead of using a single fixed value:
+// The [200, 500] range is deliberately LOW -- just above the 100-stroop
+// network minimum. The bench's goal is to fill the *remaining* space in each
+// ledger, not to crowd out real users: when organic traffic bids more than a
+// few hundred stroops/op during genuine congestion, our transactions are
+// outbid and excluded, which is the intended behavior. We are not trying to
+// win the auction, only to occupy whatever capacity organic demand leaves
+// behind. (A previous [10_000, 100_000] range aimed to clear self-induced
+// surge floors and stay above external p95s; that over-bids for a
+// fill-the-gap workload and inflates cost on pubnet.)
 //
-//  1. Stellar core's SurgePricingUtils::computeBetterFee requires a STRICTLY
-//     greater per-op fee for a new tx to evict (or beat in per-ledger
-//     inclusion ranking) one already in the queue. With identical bids,
-//     every tx after the first ties and is rejected with txINSUFFICIENT_FEE
-//     — observed at 17,666 of 18,000 OZ-transfer submits in a 5-min bench.
-//     Per-tx random sampling makes ties statistically vanishing (collision
-//     rate ~= queue_depth^2 / (2*range_size); 90,001 distinct buckets here).
-//     This is the same primitive stellar-core's own LoadGenerator
-//     (TxGenerator::generateFee) uses.
+// We still sample per-tx rather than using a single fixed value, because
+// Stellar core's SurgePricingUtils::computeBetterFee requires a STRICTLY
+// greater per-op fee for a new tx to evict (or beat in per-ledger inclusion
+// ranking) one already in the queue. With identical bids, every tx after the
+// first ties and is rejected with txINSUFFICIENT_FEE -- observed at 17,666 of
+// 18,000 OZ-transfer submits in a 5-min bench. Per-tx random sampling breaks
+// those ties (collision rate ~= queue_depth^2 / (2*range_size)). This is the
+// same primitive stellar-core's own LoadGenerator (TxGenerator::generateFee)
+// uses.
 //
-//  2. To stay above network surge floors. The [10_000, 100_000] range is
-//     a heuristic starting point: well above the 100-stroop network
-//     minimum and historical futurenet external-surge p95s in the
-//     low-thousands. It is NOT guaranteed to clear self-induced surge on
-//     resource-heavy workloads — at high RPS for OZ/soroswap the bench
-//     can saturate ledger Soroban capacity, the surge floor rises tx-by-
-//     tx, and the upper bound here can be exceeded. Cost on test networks
-//     is negligible: a 100k-stroop inclusion bid is ~0.01 XLM per tx,
-//     and the fee_payer holds free XLM. For pubnet, or for sustained
-//     high-RPS Soroban-heavy benches, the operator should re-tune these
-//     constants based on observed getFeeStats.SorobanInclusionFee.
+// Trade-off of the narrower range: only 301 distinct buckets (vs 90,001
+// before), so at ~800 tx/ledger our own submissions collide far more often.
+// That matters only when the ledger is FULL and eviction requires a strictly
+// greater bid -- i.e. exactly when we intend to yield to organic traffic
+// anyway. Below saturation there is free space, txns are admitted directly,
+// and ties are harmless. If a target network needs a different band (e.g. to
+// sit just under a specific organic surge floor), re-tune based on observed
+// getFeeStats inclusion fees.
 const (
-	benchmarkBaseFeeMin int64 = 10_000
-	benchmarkBaseFeeMax int64 = 100_000
+	benchmarkBaseFeeMin int64 = 200
+	benchmarkBaseFeeMax int64 = 500
 )
 
 // sampleBenchmarkBaseFee returns a per-op inclusion fee uniformly sampled from

--- a/cmd/tx-load-test/benchmark/tx_builder.go
+++ b/cmd/tx-load-test/benchmark/tx_builder.go
@@ -78,12 +78,15 @@ func buildSorobanSendTransactionBody(params sorobanSendTransactionParams) ([]byt
 //
 // Stellar-core enforces a self-induced surge price during sustained
 // Soroban-heavy traffic; the inclusion floor scales with how much resource
-// work each tx consumes. Sampling a 10k-100k inclusion fee on a tx whose
-// resource fee is several million stroops underbids that floor and shows up
-// as txINSUFFICIENT_FEE at submit time. Boosting the inclusion fee
-// proportionally is cheap on test networks (the fee payer is funded by
-// friendbot) and lets the fee-bump's totalFee = (numOps+1) * baseFee +
-// resourceFee actually clear the floor.
+// work each tx consumes. Sampling a low fill-the-gap inclusion fee (the usual
+// [benchmarkBaseFeeMin, benchmarkBaseFeeMax] band, a few hundred stroops) on a
+// tx whose resource fee is several million stroops underbids that floor and
+// shows up as txINSUFFICIENT_FEE at submit time. This threshold is only
+// crossed by expensive Soroban work such as autorestore -- steady-state
+// transfers have resource fees ~15k, far below heavyResourceFeeThreshold, so
+// the floor does not apply to them and the low fill-the-gap bids stand.
+// Boosting the inclusion fee for the heavy case lets the fee-bump's
+// totalFee = (numOps+1) * baseFee + resourceFee actually clear the floor.
 func benchmarkInnerBaseFee(resourceFee xdr.Int64) int64 {
 	baseFee := sampleBenchmarkBaseFee()
 	const heavyResourceFeeThreshold xdr.Int64 = 10_000_000

--- a/cmd/tx-load-test/docs/PLAN.md
+++ b/cmd/tx-load-test/docs/PLAN.md
@@ -271,8 +271,8 @@ The state model should be simple and flat. Preserve these fields or their equiva
 	"rpc_url": "https://...",
 	"network_passphrase": "...",
 	"fee_payer_hash": "hex-sha256",
-	"account_indices": [1, 2, 3],
-	"sac_holder_indices": [1, 2, 3],
+	"account_ranges": ["1-4500"],
+	"sac_holder_ranges": ["1-900"],
 	"assets": ["BLTA", "BLTB", "BLTC"],
 	"sacs": ["C...", "C...", "C..."],
 	"soroswap_factory_contract": "C...",
@@ -285,8 +285,22 @@ The state model should be simple and flat. Preserve these fields or their equiva
 
 State design requirements:
 
-- `account_indices` are the canonical source for re-deriving participant accounts
-- `sac_holder_indices` track the prefix/subset that must hold trustlines and token balances for SAC-style activity
+- participant account derivation indices are the canonical identity for the
+	pool; on disk they are stored as compact ranges (`account_ranges`), where
+	each entry is a single index (`"5"`) or an inclusive contiguous run
+	(`"1-4500"`), sorted ascending and non-overlapping. Ranges are a SET
+	encoding, not a contiguity assumption: gaps from `sync` pruning or partially
+	failed teardown batches simply produce more ranges. This keeps the file a
+	few hundred bytes regardless of pool size (thousands of accounts would
+	otherwise mean thousands of array elements), which matters for embedding
+	the file in orchestration config (e.g. a Kubernetes ConfigMap).
+- `sac_holder_ranges` track the subset that must hold trustlines and token
+	balances for SAC-style activity, in the same encoding
+- readers must also accept the legacy flat forms (`account_indices`,
+	`sac_holder_indices`) and upgrade to ranges on the next save; a file
+	carrying both encodings for the same field is rejected as ambiguous
+- the range codec must guard expansion size on load (a typo'd `"1-4000000000"`
+	must error, not allocate gigabytes)
 - fee payer secret must never appear in the file
 - the recorded network passphrase is part of state identity, not just metadata
 

--- a/cmd/tx-load-test/gcs/upload.go
+++ b/cmd/tx-load-test/gcs/upload.go
@@ -1,0 +1,85 @@
+// Package gcs uploads benchmark output files to Google Cloud Storage.
+//
+// Authentication uses Application Default Credentials: a mounted service
+// account key via GOOGLE_APPLICATION_CREDENTIALS, GKE workload identity, or
+// the GCE metadata server all work without tool configuration.
+package gcs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+)
+
+// uploadTimeout bounds a single object upload. Metrics files are small
+// (KBs); this is generous headroom for slow first-token auth flows.
+const uploadTimeout = 2 * time.Minute
+
+// destination is a parsed gs:// URL.
+type destination struct {
+	bucket string
+	object string
+}
+
+// parseDestination validates a gs://bucket[/prefix[/]] URL and resolves the
+// final object name for localPath. A URL ending in "/" (or a bare bucket) is
+// treated as a prefix and the local file's basename is appended -- with the
+// default timestamped metrics filenames this yields a unique object per run.
+// Otherwise the URL names the object exactly.
+func parseDestination(gcsURL, localPath string) (destination, error) {
+	rest, ok := strings.CutPrefix(gcsURL, "gs://")
+	if !ok {
+		return destination{}, fmt.Errorf("destination %q must start with gs://", gcsURL)
+	}
+	bucket, object, _ := strings.Cut(rest, "/")
+	if bucket == "" {
+		return destination{}, fmt.Errorf("destination %q is missing a bucket name", gcsURL)
+	}
+	if object == "" || strings.HasSuffix(object, "/") {
+		object = object + path.Base(localPath)
+	}
+	return destination{bucket: bucket, object: object}, nil
+}
+
+// Upload copies localPath to the gs:// destination and returns the final
+// object URL. The context is bounded by uploadTimeout on top of any caller
+// deadline.
+func Upload(ctx context.Context, gcsURL, localPath string) (string, error) {
+	dest, err := parseDestination(gcsURL, localPath)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", localPath, err)
+	}
+	defer f.Close()
+
+	ctx, cancel := context.WithTimeout(ctx, uploadTimeout)
+	defer cancel()
+
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return "", fmt.Errorf("create GCS client: %w", err)
+	}
+	defer client.Close()
+
+	w := client.Bucket(dest.bucket).Object(dest.object).NewWriter(ctx)
+	w.ContentType = "application/x-ndjson"
+	if _, err := io.Copy(w, f); err != nil {
+		_ = w.Close()
+		return "", fmt.Errorf("upload to gs://%s/%s: %w", dest.bucket, dest.object, err)
+	}
+	// Close finalizes the upload; errors here mean the object was not written.
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("finalize gs://%s/%s: %w", dest.bucket, dest.object, err)
+	}
+	return fmt.Sprintf("gs://%s/%s", dest.bucket, dest.object), nil
+}

--- a/cmd/tx-load-test/gcs/upload_test.go
+++ b/cmd/tx-load-test/gcs/upload_test.go
@@ -1,0 +1,95 @@
+package gcs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseDestination(t *testing.T) {
+	cases := []struct {
+		name       string
+		url        string
+		localPath  string
+		wantBucket string
+		wantObject string
+		wantErr    bool
+	}{
+		{"bare bucket appends basename", "gs://metrics", "/data/run.ndjson", "metrics", "run.ndjson", false},
+		{"bucket with trailing slash", "gs://metrics/", "/data/run.ndjson", "metrics", "run.ndjson", false},
+		{"prefix appends basename", "gs://metrics/weekly/", "/data/run.ndjson", "metrics", "weekly/run.ndjson", false},
+		{"exact object name", "gs://metrics/weekly/custom.ndjson", "/data/run.ndjson", "metrics", "weekly/custom.ndjson", false},
+		{"deep prefix", "gs://m/a/b/c/", "out.ndjson", "m", "a/b/c/out.ndjson", false},
+		{"missing scheme", "s3://metrics/x", "f", "", "", true},
+		{"empty bucket", "gs:///weekly/", "f", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dest, err := parseDestination(tc.url, tc.localPath)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantBucket, dest.bucket)
+			require.Equal(t, tc.wantObject, dest.object)
+		})
+	}
+}
+
+// TestUploadAgainstEmulatorEndpoint drives the real client through a local
+// HTTP server via STORAGE_EMULATOR_HOST (which also disables authentication),
+// verifying the uploaded bytes, target bucket/object, and returned URL.
+func TestUploadAgainstEmulatorEndpoint(t *testing.T) {
+	var gotPath, gotQuery string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/upload/") {
+			http.NotFound(w, r)
+			return
+		}
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = body
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"weekly/metrics.ndjson","bucket":"loadtest-metrics"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("STORAGE_EMULATOR_HOST", strings.TrimPrefix(srv.URL, "http://"))
+
+	local := filepath.Join(t.TempDir(), "metrics.ndjson")
+	content := []byte(`{"record_type":"summary","on_chain_included":123}` + "\n")
+	require.NoError(t, os.WriteFile(local, content, 0o600))
+
+	objectURL, err := Upload(context.Background(), "gs://loadtest-metrics/weekly/", local)
+	require.NoError(t, err)
+	require.Equal(t, "gs://loadtest-metrics/weekly/metrics.ndjson", objectURL)
+
+	require.Contains(t, gotPath, "/b/loadtest-metrics/o")
+	require.Contains(t, gotQuery, "name=weekly%2Fmetrics.ndjson")
+	// The upload is multipart (JSON metadata + payload); the payload must
+	// contain our exact NDJSON bytes.
+	require.Contains(t, string(gotBody), string(content))
+}
+
+func TestUploadMissingLocalFile(t *testing.T) {
+	_, err := Upload(context.Background(), "gs://bucket/", filepath.Join(t.TempDir(), "nope.ndjson"))
+	require.Error(t, err)
+}
+
+func TestUploadBadURL(t *testing.T) {
+	local := filepath.Join(t.TempDir(), "m.ndjson")
+	require.NoError(t, os.WriteFile(local, []byte("{}\n"), 0o600))
+	_, err := Upload(context.Background(), "http://not-gcs/", local)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "gs://")
+}

--- a/cmd/tx-load-test/root_cmd.go
+++ b/cmd/tx-load-test/root_cmd.go
@@ -15,6 +15,7 @@ func buildRootCmd() *cobra.Command {
 
 	root.AddCommand(buildSetupCmd())
 	root.AddCommand(buildBenchCmd())
+	root.AddCommand(buildRunCmd())
 	root.AddCommand(buildRestoreCmd())
 	root.AddCommand(buildTeardownCmd())
 	root.AddCommand(buildSyncCmd())

--- a/cmd/tx-load-test/run_cmd.go
+++ b/cmd/tx-load-test/run_cmd.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/benchmark"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/config"
+	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
+)
+
+// suiteModeOrder is the fixed execution order of the benchmark suite. The
+// modes share the derived account pool, so they must run sequentially; each
+// benchmark.Run reloads sequence numbers from the RPC, which makes
+// back-to-back runs against the same loaded state safe.
+var suiteModeOrder = []config.BenchmarkMode{
+	config.ModeSACTransfer,
+	config.ModeOZTransfer,
+	config.ModeSoroswap,
+}
+
+func buildRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Run the full benchmark suite (sac-transfer, oz-transfer, soroswap) sequentially",
+		Long: `run executes every benchmark mode back to back against an already
+initialized ledger (created by 'setup'): sac-transfer, then oz-transfer, then
+soroswap, each for --duration at its own per-mode rate, with the parallel
+simple-payment stream at --classic-rps alongside each.
+
+The modes share the derived account pool so they never run concurrently; a
+--pause settle gap separates them. Each mode writes its own timestamped
+metrics NDJSON file under metrics/ (as if 'bench' had been run per mode) and,
+when --metrics-gcs-url is set, uploads it right after the mode finishes so an
+upload or later-mode failure cannot lose earlier results. A failed mode aborts
+the remaining ones.
+
+This exists so scheduled runs (e.g. a Kubernetes CronJob) need a single
+invocation for the whole suite; use 'bench' for a one-off single-mode run.`,
+		RunE: runSuite,
+	}
+
+	addRuntimeStatePreflightFlags(cmd)
+	cmd.Flags().String("log-level", "info", "Log verbosity: debug | info | warn | error")
+	cmd.Flags().String("rpc-url", "", "Override the RPC URL stored in the state JSON file")
+	cmd.Flags().String("state-file", state.DefaultStateFile, "Path to the state JSON file")
+	cmd.Flags().Duration("duration", 5*time.Minute, "Benchmark duration for each mode")
+	cmd.Flags().Duration("ramp-up", 0, "Ramp-up period for each mode (RPS increases linearly from 1 to the mode's rate)")
+	cmd.Flags().Duration("pause", 30*time.Second, "Settle gap between modes")
+	cmd.Flags().Int("sac-rps", 60, "Steady-state requests per second for sac-transfer")
+	cmd.Flags().Int("oz-rps", 55, "Steady-state requests per second for oz-transfer")
+	cmd.Flags().Int("soroswap-rps", 30, "Steady-state requests per second for soroswap")
+	cmd.Flags().Int("classic-rps", config.DefaultClassicRPS, "Steady-state simple-payment transactions per second alongside each mode (1 payment op per tx)")
+	cmd.Flags().String("metrics-gcs-url", "", "Optional gs://bucket/prefix/ destination; each mode's metrics file is uploaded there after the mode finishes (auth via Application Default Credentials)")
+	return cmd
+}
+
+func runSuite(cmd *cobra.Command, _ []string) error {
+	logger, err := makeLogger(cmd, "tx-load-test/run")
+	if err != nil {
+		return err
+	}
+
+	duration, err := cmd.Flags().GetDuration("duration")
+	if err != nil {
+		return err
+	}
+	rampUp, err := cmd.Flags().GetDuration("ramp-up")
+	if err != nil {
+		return err
+	}
+	pause, err := cmd.Flags().GetDuration("pause")
+	if err != nil {
+		return err
+	}
+	classicRPS, err := cmd.Flags().GetInt("classic-rps")
+	if err != nil {
+		return err
+	}
+	metricsGCSURL, err := cmd.Flags().GetString("metrics-gcs-url")
+	if err != nil {
+		return err
+	}
+	modeRPS := map[config.BenchmarkMode]string{
+		config.ModeSACTransfer: "sac-rps",
+		config.ModeOZTransfer:  "oz-rps",
+		config.ModeSoroswap:    "soroswap-rps",
+	}
+
+	cfgs := make([]config.Config, 0, len(suiteModeOrder))
+	for _, mode := range suiteModeOrder {
+		targetRPS, err := cmd.Flags().GetInt(modeRPS[mode])
+		if err != nil {
+			return err
+		}
+		cfg := config.DefaultConfig()
+		cfg.Mode = mode
+		cfg.Duration = duration
+		cfg.RampUp = rampUp
+		cfg.TargetRPS = targetRPS
+		cfg.ClassicRPS = classicRPS
+		if err := benchmark.ValidateCLIConfig(cfg); err != nil {
+			return fmt.Errorf("%s: %w", mode, err)
+		}
+		cfgs = append(cfgs, cfg)
+	}
+
+	stateFile, loaded, err := loadRuntimeStateFromCommand(cmd, state.RuntimePhaseBench)
+	if err != nil {
+		return err
+	}
+	// Validate every mode before the first one starts, so a config/pool
+	// problem in a later mode fails immediately instead of after most of the
+	// suite has already run.
+	for i := range cfgs {
+		cfgs[i].RPCURL = loaded.RPCURL
+		cfgs[i].NetworkPassphrase = loaded.Persisted.NetworkPassphrase
+		cfgs[i].NumberOfAccounts = len(loaded.Persisted.AccountIndices)
+		if err := benchmark.ValidateConfig(cfgs[i]); err != nil {
+			return fmt.Errorf("%s: %w", cfgs[i].Mode, err)
+		}
+	}
+
+	ctx, cancel := signalCommandContext(cmd, logger, true)
+	defer cancel()
+
+	logger.Infof("loaded state from %s (%d accounts, rpc=%s)", stateFile, cfgs[0].NumberOfAccounts, loaded.RPCURL)
+
+	for i, cfg := range cfgs {
+		if i > 0 && pause > 0 {
+			logger.Infof("pausing %s before %s", pause, cfg.Mode)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pause):
+			}
+		}
+
+		cfg.MetricsFile = benchmark.DefaultMetricsFileName(cfg.Mode, time.Now())
+		scoped := logger.WithField("mode", string(cfg.Mode))
+		scoped.Infof("benchmark metrics NDJSON file: %s", cfg.MetricsFile)
+
+		connCap := max(1, (cfg.TargetRPS+state.SimplePaymentTransactionRate(cfg))*4)
+		httpClient := &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        connCap,
+				MaxIdleConnsPerHost: connCap,
+				MaxConnsPerHost:     connCap,
+			},
+		}
+
+		runErr := benchmark.Run(ctx, scoped, cfg, loaded.Live, httpClient)
+		if runErr != nil {
+			scoped.WithError(runErr).Error("benchmark failed")
+		}
+		if uploadErr := uploadMetricsIfRequested(scoped, metricsGCSURL, cfg.MetricsFile); uploadErr != nil && runErr == nil {
+			runErr = uploadErr
+		}
+		if runErr != nil {
+			return fmt.Errorf("%s: %w", cfg.Mode, runErr)
+		}
+	}
+
+	logger.Infof("benchmark suite complete (%d modes)", len(cfgs))
+	return nil
+}

--- a/cmd/tx-load-test/state/ranges.go
+++ b/cmd/tx-load-test/state/ranges.go
@@ -1,0 +1,97 @@
+package state
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// maxDecodedIndices caps how many account indices a ranges list may expand to.
+// This guards against a typo'd or hostile range ("1-4000000000") allocating
+// gigabytes on load. The cap is far above any realistic pool size -- benchmark
+// economics (reserves, rent) bind orders of magnitude earlier.
+const maxDecodedIndices = 1 << 20
+
+// encodeIndexRanges compresses a set of derivation indices into the compact
+// range form persisted on disk: contiguous runs render as "a-b", singletons as
+// "a". The input is treated as a SET: it is copied, sorted ascending, and
+// deduplicated, so arbitrary in-memory ordering does not survive encoding.
+// Returns nil for an empty input so the JSON field is omitted entirely.
+func encodeIndexRanges(indices []int) []string {
+	if len(indices) == 0 {
+		return nil
+	}
+	sorted := slices.Clone(indices)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+
+	ranges := make([]string, 0, 4)
+	start, end := sorted[0], sorted[0]
+	flush := func() {
+		if start == end {
+			ranges = append(ranges, strconv.Itoa(start))
+			return
+		}
+		ranges = append(ranges, strconv.Itoa(start)+"-"+strconv.Itoa(end))
+	}
+	for _, idx := range sorted[1:] {
+		if idx == end+1 {
+			end = idx
+			continue
+		}
+		flush()
+		start, end = idx, idx
+	}
+	flush()
+	return ranges
+}
+
+// decodeIndexRanges expands the compact on-disk range form back into a flat,
+// ascending index list. It validates canonical form: each entry is "a" or
+// "a-b" with 0 <= a <= b, entries are strictly ascending, and ranges do not
+// touch or overlap (the encoder would have merged them). The expansion size is
+// capped by maxDecodedIndices.
+func decodeIndexRanges(ranges []string) ([]int, error) {
+	if len(ranges) == 0 {
+		return nil, nil
+	}
+	indices := make([]int, 0, len(ranges))
+	prevEnd := -2 // allows a first range starting at 0
+	for i, r := range ranges {
+		start, end, err := parseIndexRange(r)
+		if err != nil {
+			return nil, fmt.Errorf("range[%d] %q: %w", i, r, err)
+		}
+		if start <= prevEnd+1 {
+			return nil, fmt.Errorf("range[%d] %q is not in canonical form: ranges must be ascending and non-adjacent (previous range ended at %d)", i, r, prevEnd)
+		}
+		if len(indices)+(end-start+1) > maxDecodedIndices {
+			return nil, fmt.Errorf("range[%d] %q expands the index list past the %d-entry limit", i, r, maxDecodedIndices)
+		}
+		for idx := start; idx <= end; idx++ {
+			indices = append(indices, idx)
+		}
+		prevEnd = end
+	}
+	return indices, nil
+}
+
+func parseIndexRange(r string) (int, int, error) {
+	lo, hi, isRange := strings.Cut(r, "-")
+	start, err := strconv.Atoi(lo)
+	if err != nil || start < 0 {
+		return 0, 0, fmt.Errorf("invalid start index %q", lo)
+	}
+	if !isRange {
+		return start, start, nil
+	}
+	end, err := strconv.Atoi(hi)
+	if err != nil || end < 0 {
+		return 0, 0, fmt.Errorf("invalid end index %q", hi)
+	}
+	if end < start {
+		return 0, 0, fmt.Errorf("end %d is below start %d", end, start)
+	}
+	return start, end, nil
+}

--- a/cmd/tx-load-test/state/ranges_test.go
+++ b/cmd/tx-load-test/state/ranges_test.go
@@ -1,0 +1,183 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeIndexRanges(t *testing.T) {
+	cases := []struct {
+		name    string
+		indices []int
+		want    []string
+	}{
+		{"empty", nil, nil},
+		{"single", []int{5}, []string{"5"}},
+		{"contiguous", []int{1, 2, 3, 4, 5}, []string{"1-5"}},
+		{"hole in middle", []int{1, 2, 3, 5, 6}, []string{"1-3", "5-6"}},
+		{"isolated singletons", []int{1, 3, 7}, []string{"1", "3", "7"}},
+		{"mixed", []int{1, 2, 3, 4, 4000, 4001, 9999}, []string{"1-4", "4000-4001", "9999"}},
+		{"unsorted with duplicates canonicalizes", []int{5, 1, 3, 2, 5, 4}, []string{"1-5"}},
+		{"zero is a valid index", []int{0, 1, 2}, []string{"0-2"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, encodeIndexRanges(tc.indices))
+		})
+	}
+}
+
+func TestDecodeIndexRanges(t *testing.T) {
+	t.Run("roundtrips", func(t *testing.T) {
+		for _, indices := range [][]int{
+			{1},
+			{1, 2, 3, 4, 5},
+			{1, 2, 3, 4000, 4001, 9999},
+			{0, 2, 4, 6},
+		} {
+			got, err := decodeIndexRanges(encodeIndexRanges(indices))
+			require.NoError(t, err)
+			require.Equal(t, indices, got)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		got, err := decodeIndexRanges(nil)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("rejects malformed", func(t *testing.T) {
+		for _, ranges := range [][]string{
+			{"abc"},
+			{""},
+			{"1-"},
+			{"-3"},        // parses as empty start
+			{"3--5"},      // negative end
+			{"5-1"},       // end below start
+			{"1-3", "2-6"}, // overlapping
+			{"1-3", "4-6"}, // adjacent: encoder would have merged, not canonical
+			{"5-9", "1-3"}, // descending
+			{"1-3", "3"},   // duplicate boundary
+		} {
+			_, err := decodeIndexRanges(ranges)
+			require.Error(t, err, "ranges %v should be rejected", ranges)
+		}
+	})
+
+	t.Run("caps expansion size", func(t *testing.T) {
+		_, err := decodeIndexRanges([]string{fmt.Sprintf("1-%d", maxDecodedIndices+10)})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "limit")
+	})
+}
+
+func minimalPersistedState(indices, holders []int) *PersistedState {
+	return &PersistedState{
+		RPCURL:            "http://localhost:8000",
+		NetworkPassphrase: "Test SDF Network ; September 2015",
+		FeePayerHash:      "abc123",
+		AccountIndices:    indices,
+		SACHolderIndices:  holders,
+	}
+}
+
+func TestSaveWritesRangesAndLoadRestoresIndices(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	// Simulate a post-partial-teardown pool: hole in the middle of the tail.
+	indices := make([]int, 0, 4500)
+	for i := 1; i <= 4500; i++ {
+		if i >= 4000 && i < 4100 { // a failed middle batch left a gap
+			continue
+		}
+		indices = append(indices, i)
+	}
+	holders := make([]int, 0, 900)
+	for i := 1; i <= 900; i++ {
+		holders = append(holders, i)
+	}
+	ps := minimalPersistedState(indices, holders)
+	require.NoError(t, ps.Save(path))
+
+	// Receiver must not be mutated by Save.
+	require.Equal(t, indices, ps.AccountIndices)
+	require.Nil(t, ps.AccountRanges)
+
+	// The raw file must carry the compact form only.
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var onDisk map[string]any
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	require.NotContains(t, onDisk, "account_indices")
+	require.NotContains(t, onDisk, "sac_holder_indices")
+	require.Equal(t, []any{"1-3999", "4100-4500"}, onDisk["account_ranges"])
+	require.Equal(t, []any{"1-900"}, onDisk["sac_holder_ranges"])
+	// The whole point: the file stays tiny even for thousands of accounts.
+	require.Less(t, len(raw), 2048, "range-encoded state file should be under 2 KiB")
+
+	// Loading restores the exact index lists and clears the range fields.
+	loaded, err := NewPersistedState(path)
+	require.NoError(t, err)
+	require.Equal(t, indices, loaded.AccountIndices)
+	require.Equal(t, holders, loaded.SACHolderIndices)
+	require.Nil(t, loaded.AccountRanges)
+	require.Nil(t, loaded.SACHolderRanges)
+}
+
+func TestLoadAcceptsLegacyIndexArrays(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	legacy := `{
+		"rpc_url": "http://localhost:8000",
+		"network_passphrase": "Test SDF Network ; September 2015",
+		"fee_payer_hash": "abc123",
+		"account_indices": [1, 2, 3, 7, 9],
+		"sac_holder_indices": [1, 2]
+	}`
+	require.NoError(t, os.WriteFile(path, []byte(legacy), 0o600))
+
+	loaded, err := NewPersistedState(path)
+	require.NoError(t, err)
+	require.Equal(t, []int{1, 2, 3, 7, 9}, loaded.AccountIndices)
+	require.Equal(t, []int{1, 2}, loaded.SACHolderIndices)
+
+	// First save upgrades the file to the range form in place.
+	require.NoError(t, loaded.Save(path))
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var onDisk map[string]any
+	require.NoError(t, json.Unmarshal(raw, &onDisk))
+	require.NotContains(t, onDisk, "account_indices")
+	require.Equal(t, []any{"1-3", "7", "9"}, onDisk["account_ranges"])
+}
+
+func TestLoadRejectsBothEncodings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	conflicted := `{
+		"rpc_url": "http://localhost:8000",
+		"network_passphrase": "Test SDF Network ; September 2015",
+		"fee_payer_hash": "abc123",
+		"account_indices": [1, 2, 3],
+		"account_ranges": ["1-3"]
+	}`
+	require.NoError(t, os.WriteFile(path, []byte(conflicted), 0o600))
+	_, err := NewPersistedState(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "both")
+}
+
+func TestSaveLoadRoundTripEmptyPool(t *testing.T) {
+	// A fully-torn-down state (zero accounts) must round-trip without
+	// producing empty range arrays or failing validation.
+	path := filepath.Join(t.TempDir(), "state.json")
+	ps := minimalPersistedState(nil, nil)
+	require.NoError(t, ps.Save(path))
+	loaded, err := NewPersistedState(path)
+	require.NoError(t, err)
+	require.Empty(t, loaded.AccountIndices)
+	require.Empty(t, loaded.SACHolderIndices)
+}

--- a/cmd/tx-load-test/state/state.go
+++ b/cmd/tx-load-test/state/state.go
@@ -53,12 +53,28 @@ type PersistedState struct {
 	// AccountIndices are the DeriveKeypair indices of all participant
 	// accounts. Typically contiguous (1..N), but may have gaps after sync
 	// or partial teardown.
-	AccountIndices []int `json:"account_indices"`
+	//
+	// On disk this is stored compactly as AccountRanges; this field remains
+	// the in-memory canonical form (populated by NewPersistedState from either
+	// representation) and is accepted on read for legacy state files.
+	AccountIndices []int `json:"account_indices,omitempty"`
+
+	// AccountRanges is the compact on-disk encoding of AccountIndices: each
+	// entry is a single index ("5") or an inclusive contiguous run ("1-4500"),
+	// ascending and non-overlapping. Save always writes this form; a 4,500
+	// account pool serializes as one short string instead of 4,500 array
+	// elements. Ordering is canonicalized (sorted ascending, deduplicated).
+	AccountRanges []string `json:"account_ranges,omitempty"`
 
 	// SACHolderIndices are the derivation indices of the participant accounts
 	// that hold classic trustlines and participate in SAC transfer benchmarks.
 	// This is typically the first formula-derived holder-count accounts.
+	// Stored on disk as SACHolderRanges; see AccountIndices.
 	SACHolderIndices []int `json:"sac_holder_indices,omitempty"`
+
+	// SACHolderRanges is the compact on-disk encoding of SACHolderIndices;
+	// see AccountRanges.
+	SACHolderRanges []string `json:"sac_holder_ranges,omitempty"`
 
 	// Assets holds the 3 benchmark asset codes (issuer = fee payer).
 	Assets [3]string `json:"assets"`
@@ -88,7 +104,11 @@ type PersistedState struct {
 	CleanedUp bool `json:"cleaned_up"`
 }
 
-// NewPersistedState reads a PersistedState from path.
+// NewPersistedState reads a PersistedState from path. Both index encodings
+// are accepted on read -- the compact range form written by current versions
+// and the flat index arrays written by older ones -- and normalized so that
+// AccountIndices / SACHolderIndices are always the populated, canonical
+// in-memory representation.
 func NewPersistedState(path string) (*PersistedState, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -98,10 +118,43 @@ func NewPersistedState(path string) (*PersistedState, error) {
 	if err := json.Unmarshal(data, &ps); err != nil {
 		return nil, fmt.Errorf("parse state file: %w", err)
 	}
+	if err := ps.normalizeIndexEncoding(); err != nil {
+		return nil, fmt.Errorf("parse state file: %w", err)
+	}
 	if err := ps.Validate(); err != nil {
 		return nil, fmt.Errorf("validate state file: %w", err)
 	}
 	return &ps, nil
+}
+
+// normalizeIndexEncoding expands the on-disk range encoding into the in-memory
+// flat index lists. A file carrying BOTH encodings for the same field is
+// rejected rather than silently preferring one -- that only happens via hand
+// editing, and guessing wrong would target the wrong accounts.
+func (ps *PersistedState) normalizeIndexEncoding() error {
+	if len(ps.AccountRanges) > 0 {
+		if len(ps.AccountIndices) > 0 {
+			return fmt.Errorf("state file has both account_ranges and account_indices; remove one")
+		}
+		indices, err := decodeIndexRanges(ps.AccountRanges)
+		if err != nil {
+			return fmt.Errorf("account_ranges: %w", err)
+		}
+		ps.AccountIndices = indices
+		ps.AccountRanges = nil
+	}
+	if len(ps.SACHolderRanges) > 0 {
+		if len(ps.SACHolderIndices) > 0 {
+			return fmt.Errorf("state file has both sac_holder_ranges and sac_holder_indices; remove one")
+		}
+		indices, err := decodeIndexRanges(ps.SACHolderRanges)
+		if err != nil {
+			return fmt.Errorf("sac_holder_ranges: %w", err)
+		}
+		ps.SACHolderIndices = indices
+		ps.SACHolderRanges = nil
+	}
+	return nil
 }
 
 // Validate checks that the persisted state contains the minimum required
@@ -162,9 +215,16 @@ func (ps *PersistedState) ValidateRPCNetwork(ctx context.Context, rpcURL string)
 }
 
 // Save writes ps to path as indented JSON, creating or overwriting the
-// file atomically (write to .tmp then rename).
+// file atomically (write to .tmp then rename). Index lists are always
+// serialized in the compact range form (account_ranges / sac_holder_ranges);
+// the receiver itself is not mutated.
 func (ps *PersistedState) Save(path string) error {
-	data, err := json.MarshalIndent(ps, "", "  ")
+	out := *ps
+	out.AccountRanges = encodeIndexRanges(ps.AccountIndices)
+	out.AccountIndices = nil
+	out.SACHolderRanges = encodeIndexRanges(ps.SACHolderIndices)
+	out.SACHolderIndices = nil
+	data, err := json.MarshalIndent(&out, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal state: %w", err)
 	}

--- a/cmd/tx-load-test/tools/derive-oz-accounts/main.go
+++ b/cmd/tx-load-test/tools/derive-oz-accounts/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -12,13 +11,6 @@ import (
 
 	"github.com/stellar/stellar-rpc-blaster/cmd/tx-load-test/state"
 )
-
-type persistedState struct {
-	FeePayerHash    string   `json:"fee_payer_hash"`
-	AccountIndices  []uint32 `json:"account_indices"`
-	OZTokenContract string   `json:"oz_token_contract"`
-	CleanedUp       bool     `json:"cleaned_up"`
-}
 
 func main() {
 	flag.Usage = func() {
@@ -49,14 +41,11 @@ func run(seed string, publicKeysCSV string, stateFile string) error {
 		return err
 	}
 
-	data, err := os.ReadFile(stateFile)
+	// Load through the state package so both index encodings (compact
+	// account_ranges and legacy account_indices) are understood.
+	st, err := state.NewPersistedState(stateFile)
 	if err != nil {
-		return fmt.Errorf("read state file %q: %w", stateFile, err)
-	}
-
-	var st persistedState
-	if err := json.Unmarshal(data, &st); err != nil {
-		return fmt.Errorf("parse state file %q: %w", stateFile, err)
+		return fmt.Errorf("load state file %q: %w", stateFile, err)
 	}
 	if st.CleanedUp {
 		return fmt.Errorf("state file is marked cleaned_up=true")
@@ -78,7 +67,7 @@ func run(seed string, publicKeysCSV string, stateFile string) error {
 
 	seedsByPublicKey := make(map[string]string, len(st.AccountIndices))
 	for _, index := range st.AccountIndices {
-		kp, err := state.DeriveKeypair(feePayer, int(index))
+		kp, err := state.DeriveKeypair(feePayer, index)
 		if err != nil {
 			return fmt.Errorf("derive account index %d: %w", index, err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
-	cloud.google.com/go/storage v1.60.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
@@ -93,6 +92,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/storage v1.60.0
 	github.com/HdrHistogram/hdrhistogram-go v1.2.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stellar/go-stellar-sdk v0.4.0


### PR DESCRIPTION
* Containerize tool and push to internal docker registry
* Add support for uploading metrics to GCS
* Lower jitter fee ceiling to lower run cost
* Add `run` command that just runs all three modes