### PR TITLE
Add note making this repo out-of-scope for bug bounty rewards

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy and Bug Bounty Eligibility
+
+stellar-rpc-blaster is excluded from Stellar's bug bounty program.
+
+To review the details of the program, see the [Stellar bug bounty program](https://www.stellar.org/bug-bounty-program/).

--- a/cmd/stellar-rpc-blaster/README.md
+++ b/cmd/stellar-rpc-blaster/README.md
@@ -241,3 +241,7 @@ Each timeline entry corresponds to one step interval (default 5s) and contains:
 | `p50_ms` ... `p99.9_ms` | Latency percentiles for this window only |
 
 The timeline reveals the degradation curve: scan for where `error_rate_pct` jumps from 0 and where `p99_ms` spikes — that's the RPS at which the RPC buckled.
+
+---
+
+> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.


### PR DESCRIPTION
### What

Adds a line to the README that makes this repo out-of-scope for bug bounty rewards.

### Why

As this repo is a load testing tool, it was never intended to be eligible for bug bounty rewards.