### PR TITLE
Scriptability improvements: expose endpoint limits, add cooloff flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
-/cmd/stellar-rpc-blaster/output/*
-!/cmd/stellar-rpc-blaster/output/.gitkeep
+/output/*
+!/output/.gitkeep
 /stellar-rpc-blaster

--- a/cmd/stellar-rpc-blaster/README.md
+++ b/cmd/stellar-rpc-blaster/README.md
@@ -50,6 +50,7 @@ Execute a load test.
 | `--test-output-path` | string | `./output` | `TEST_OUTPUT_PATH` | Results output: a directory (timestamped `test-results-*.json` created inside) or an explicit `.json` file path |
 | `--input-data-path` | string | — | `INPUT_DATA_PATH` | Path to seed data file (from `generate`) |
 | `--serial` | bool | `false` | `SERIAL` | Run endpoints one at a time instead of concurrently |
+| `--cooloff` | duration | `0` | `COOLOFF` | Delay between endpoints in serial mode so one endpoint's failures don't cascade into the next (e.g. `30s`); requires `--serial` |
 
 ### `generate`
 
@@ -125,6 +126,8 @@ All configured endpoints blast simultaneously for the full `--duration`.
 ### Serial (`--serial`)
 
 Endpoints run one at a time. Each gets the full `--duration`, so total test time is `duration * number_of_endpoints`. Useful for isolating per-endpoint behavior without cross-endpoint interference.
+
+Pass `--cooloff <duration>` to insert a delay between successive endpoints, giving a struggling server time to recover so one endpoint's failures don't cascade into the next. With cooloff, total test time becomes `duration * number_of_endpoints + cooloff * (number_of_endpoints - 1)`. It only applies in serial mode.
 
 ## Ramp-Up and Stepped Pacer
 

--- a/cmd/stellar-rpc-blaster/README.md
+++ b/cmd/stellar-rpc-blaster/README.md
@@ -23,7 +23,7 @@ make build-rpc-blaster
   --ramp-up 30s
 ```
 
-Results are written to `./cmd/stellar-rpc-blaster/output/test-results-<timestamp>.json`.
+Results are written to `./output/test-results-<timestamp>.json`.
 
 ## Build
 
@@ -47,7 +47,7 @@ Execute a load test.
 | `--duration` | duration | *(required)* | `DURATION` | Test duration (e.g. `60s`, `5m`) |
 | `--ramp-up` | duration | `0` | `RAMP_UP` | Ramp-up period before reaching target RPS |
 | `--step-interval` | duration | `5s` | `STEP_INTERVAL` | Time between RPS step increases during ramp |
-| `--test-output-path` | string | `./cmd/stellar-rpc-blaster/output` | `TEST_OUTPUT_PATH` | Base directory for results JSON |
+| `--test-output-path` | string | `./output` | `TEST_OUTPUT_PATH` | Results output: a directory (timestamped `test-results-*.json` created inside) or an explicit `.json` file path |
 | `--input-data-path` | string | — | `INPUT_DATA_PATH` | Path to seed data file (from `generate`) |
 | `--serial` | bool | `false` | `SERIAL` | Run endpoints one at a time instead of concurrently |
 

--- a/cmd/stellar-rpc-blaster/internal/app.go
+++ b/cmd/stellar-rpc-blaster/internal/app.go
@@ -142,13 +142,20 @@ func (a *App) runGenerate(ctx context.Context) error {
 	return g.Generate(ctx, a.logger, a.config)
 }
 
+// setOutput resolves TestOutputPath to a results file: an explicit .json path is
+// used as-is, anything else is treated as a directory and gets a timestamped filename.
 func (a *App) setOutput(runtimeSettings *config.RuntimeSettings) error {
-	if runtimeSettings.Mode == config.Run {
-		if err := os.MkdirAll(runtimeSettings.TestOutputPath, 0o755); err != nil {
-			return fmt.Errorf("could not create output directory: %w", err)
-		}
-		filename := fmt.Sprintf("test-results-%s.json", time.Now().Format("2006-01-02T15-04-05"))
-		runtimeSettings.TestOutputPath = filepath.Join(runtimeSettings.TestOutputPath, filename)
+	if runtimeSettings.Mode != config.Run {
+		return nil
 	}
+	path := runtimeSettings.TestOutputPath
+	if filepath.Ext(path) != ".json" {
+		filename := fmt.Sprintf("test-results-%s.json", time.Now().Format("2006-01-02T15-04-05"))
+		path = filepath.Join(path, filename)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("could not create output directory: %w", err)
+	}
+	runtimeSettings.TestOutputPath = path
 	return nil
 }

--- a/cmd/stellar-rpc-blaster/internal/cli/cli.go
+++ b/cmd/stellar-rpc-blaster/internal/cli/cli.go
@@ -50,6 +50,7 @@ func makeCommands() *cobra.Command {
 				cmd.Flags().Lookup("test-output-path"),
 				cmd.Flags().Lookup("input-data-path"),
 				cmd.Flags().Lookup("serial"),
+				cmd.Flags().Lookup("cooloff"),
 				cmd.Flags().Lookup("error-percent"),
 			)
 			settings.Mode = config.Run
@@ -93,6 +94,7 @@ func makeCommands() *cobra.Command {
 	runCmd.Flags().Duration("ramp-up", time.Duration(0), "Ramp-up time before reaching target RPS (e.g., 30s)")
 	runCmd.Flags().Duration("step-interval", time.Second*5, "Interval between steps during the test (e.g., 5s)")
 	runCmd.Flags().Bool("serial", false, "Run endpoints one at a time sequentially instead of concurrently")
+	runCmd.Flags().Duration("cooloff", time.Duration(0), "Delay between endpoints in serial mode so one endpoint's failures don't cascade into the next (e.g. 30s)")
 	runCmd.Flags().Int("error-percent", 50, "Threshold for error percentage to kill the test (e.g. 50 means kill at 50%)")
 
 	generateCmd.Flags().String("output", "./output/seed.json", "Path to seed data file output by generate")
@@ -118,6 +120,7 @@ func bindRunCliParameters(
 	testOutputPath *pflag.Flag,
 	inputDataPath *pflag.Flag,
 	serial *pflag.Flag,
+	cooloff *pflag.Flag,
 	errorPercent *pflag.Flag,
 ) config.RuntimeSettings {
 	bindFlag := func(flag *pflag.Flag) {
@@ -132,6 +135,7 @@ func bindRunCliParameters(
 	bindFlag(testOutputPath)
 	bindFlag(inputDataPath)
 	bindFlag(serial)
+	bindFlag(cooloff)
 	bindFlag(errorPercent)
 	settings := config.RuntimeSettings{}
 	settings.ConfigPath = viper.GetString(cfgPath.Name)
@@ -142,6 +146,7 @@ func bindRunCliParameters(
 	settings.TestOutputPath = viper.GetString(testOutputPath.Name)
 	settings.InputDataPath = viper.GetString(inputDataPath.Name)
 	settings.Serial = viper.GetBool(serial.Name)
+	settings.Cooloff = viper.GetViper().GetDuration(cooloff.Name)
 	settings.ErrorPercent = viper.GetInt(errorPercent.Name)
 
 	return settings

--- a/cmd/stellar-rpc-blaster/internal/cli/cli.go
+++ b/cmd/stellar-rpc-blaster/internal/cli/cli.go
@@ -87,7 +87,7 @@ func makeCommands() *cobra.Command {
 	commonFlags.String("rpc-url", "", "Target RPC server URL")
 
 	runCmd.Flags().String("config-path", "", "Path to config TOML file")
-	runCmd.Flags().String("test-output-path", "./cmd/stellar-rpc-blaster/output", "Base directory for run output (logs and results)")
+	runCmd.Flags().String("test-output-path", "./output", "Results output: a directory (timestamped test-results-*.json created inside) or an explicit .json file path")
 	runCmd.Flags().String("input-data-path", "", "Path to seed data file output by generate, required for data-dependent endpoints")
 	runCmd.Flags().Duration("duration", time.Duration(0), "Duration to run the test (e.g., 5m)")
 	runCmd.Flags().Duration("ramp-up", time.Duration(0), "Ramp-up time before reaching target RPS (e.g., 30s)")
@@ -95,7 +95,7 @@ func makeCommands() *cobra.Command {
 	runCmd.Flags().Bool("serial", false, "Run endpoints one at a time sequentially instead of concurrently")
 	runCmd.Flags().Int("error-percent", 50, "Threshold for error percentage to kill the test (e.g. 50 means kill at 50%)")
 
-	generateCmd.Flags().String("output", "./cmd/stellar-rpc-blaster/output/seed.json", "Path to seed data file output by generate")
+	generateCmd.Flags().String("output", "./output/seed.json", "Path to seed data file output by generate")
 	generateCmd.Flags().String("ledger-window", "", "Ledger range as START[,END] for data generation")
 	generateCmd.Flags().Uint32("count", 5000, "Number of ledgers to sample from the ledger window")
 

--- a/cmd/stellar-rpc-blaster/internal/config/config.example.toml
+++ b/cmd/stellar-rpc-blaster/internal/config/config.example.toml
@@ -2,42 +2,54 @@
 # Each endpoint can be configured with:
 # [endpoints.ENDPOINT_NAME]
 #   rps          - requests per second
+#   start_rps    - starting requests per second, optional
+#   limit        - limit (only for paginated endpoints, optional)
 # Specify the seed data input path for data dependent endpoints with:
 # data_path = "PATH/TO/INPUTDATA.json"
 # Using the default seed data output path, this is "./output/seed.json" 
-input_data_path = "./output/seed.json"
 
-# # No-parameter/run-only endpoints
-# [endpoints.getHealth]
-# rps = 20
+[endpoints.getHealth]
+rps = 15
+start_rps = 10
 
-# [endpoints.getNetwork]
-# rps = 150
-# start_rps = 12
+[endpoints.getLatestLedger]
+rps = 15
+start_rps = 10
 
-# [endpoints.getVersionInfo]
-# rps = 20
+[endpoints.getNetwork]
+rps = 15
+start_rps = 10
 
-# [endpoints.getLatestLedger]
-# rps = 20
-# start_rps = 10
+[endpoints.getVersionInfo]
+rps = 15
+start_rps = 10
 
-# [endpoints.getFeeStats]
-# rps = 20
+[endpoints.getFeeStats]
+rps = 15
+start_rps = 5
 
-# Parameter-based/generate-required endpoints
+[endpoints.getLedgerEntries]
+rps = 15
+start_rps = 5
+
+[endpoints.getTransaction]
+rps = 15
+start_rps = 5
+
+# The paginated endpoints take a limit
+
+# Temporarily disabled due to highly-variable response times depending on query pattern
 # [endpoints.getEvents]
 # rps = 1
-
-# [endpoints.getLedgerEntries]
-# rps = 20
-# start_rps = 10
+# start_rps = 1
+# limit = 1
 
 [endpoints.getLedgers]
-rps = 50
+rps = 1
+start_rps = 1
+limit = 1
 
-# [endpoints.getTransaction]
-# rps = 20
-
-# [endpoints.getTransactions]
-# rps = 10
+[endpoints.getTransactions]
+rps = 1
+start_rps = 1
+limit = 1

--- a/cmd/stellar-rpc-blaster/internal/config/configs.go
+++ b/cmd/stellar-rpc-blaster/internal/config/configs.go
@@ -31,9 +31,10 @@ type Config struct {
 	Duration       time.Duration
 	RampUp         time.Duration
 	StepInterval   time.Duration
-	Serial         bool   // run endpoints one at a time instead of concurrently
-	TestOutputPath string // path to write JSON results
-	ErrorPercent   int    // threshold for error percentage to kill the test (e.g. 50 means 50%)
+	Serial         bool          // run endpoints one at a time instead of concurrently
+	Cooloff        time.Duration // delay between endpoints in serial mode so failures don't cascade
+	TestOutputPath string        // path to write JSON results
+	ErrorPercent   int           // threshold for error percentage to kill the test (e.g. 50 means 50%)
 
 	// Generate mode settings
 	OutputPath   string
@@ -74,6 +75,7 @@ type RuntimeSettings struct {
 	RampUp         time.Duration
 	StepInterval   time.Duration
 	Serial         bool
+	Cooloff        time.Duration
 	ErrorPercent   int
 
 	// Generate mode settings
@@ -117,6 +119,7 @@ func NewConfig(
 		cfg.RampUp = settings.RampUp
 		cfg.StepInterval = settings.StepInterval
 		cfg.Serial = settings.Serial
+		cfg.Cooloff = settings.Cooloff
 		cfg.TestOutputPath = settings.TestOutputPath
 		if err := cfg.processToml(settings.ConfigPath); err != nil {
 			return Config{}, err
@@ -162,6 +165,13 @@ func (c *Config) processToml(tomlPath string) error {
 func (c *Config) validateEndpointConfig() error {
 	if c.ErrorPercent < 0 || c.ErrorPercent > 100 {
 		return fmt.Errorf("error-percent must be between 0 and 100")
+	}
+
+	if c.Cooloff < 0 {
+		return fmt.Errorf("cooloff must not be negative")
+	}
+	if c.Cooloff > 0 && !c.Serial {
+		return fmt.Errorf("cooloff only applies in serial mode; pass --serial")
 	}
 
 	if c.RampUp > 0 {

--- a/cmd/stellar-rpc-blaster/internal/run/engine/run.go
+++ b/cmd/stellar-rpc-blaster/internal/run/engine/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 
@@ -103,10 +104,20 @@ func NewBlastEngine(
 // Run executes the blast according to the engine's configuration, sending results to the OutCh for aggregation
 func (b *BlastEngine) Run(ctx context.Context, logger *log.Entry, aggregator *blasterMetrics.Aggregator) {
 	if b.cfg.Serial {
-		for _, blast := range b.BlastSpecs {
+		for i, blast := range b.BlastSpecs {
 			if ctx.Err() != nil {
 				logger.Errorf("Endpoint blasts terminating early due to context error: %s", ctx.Err().Error())
 				return
+			}
+			// Cool off between endpoints so a struggling server can recover before the next blast
+			if i > 0 && b.cfg.Cooloff > 0 {
+				logger.Infof("Cooling off for %s before next endpoint", b.cfg.Cooloff)
+				select {
+				case <-time.After(b.cfg.Cooloff):
+				case <-ctx.Done():
+					logger.Errorf("Endpoint blasts terminating early during cooloff: %s", ctx.Err().Error())
+					return
+				}
 			}
 			aggregator.ActivateEndpoint(blast.EndpointKey)
 			logger.Infof("Serial mode: starting endpoint %s", blast.EndpointKey)

--- a/cmd/stellar-rpc-blaster/internal/run/metrics/aggregator.go
+++ b/cmd/stellar-rpc-blaster/internal/run/metrics/aggregator.go
@@ -42,6 +42,7 @@ type EndpointStats struct {
 	percentiles  map[float64]time.Duration
 	startRPS     float64
 	targetRPS    float64
+	limit        uint64 // effective per-request limit; 0 for endpoints without pagination
 	startTime    time.Time     // set on activation; zero means inactive
 	stepInterval time.Duration // window size for timeline snapshots
 	windows      []windowStats // per-step-interval accumulators
@@ -124,6 +125,7 @@ func NewAggregator(logger *log.Entry, settings config.Config, cancel context.Can
 			percentiles:  make(map[float64]time.Duration),
 			errorTypes:   make(map[string]ErrorResult),
 			startRPS:     float64(max(settings.GetEndpointStartRPS(endpointKey), 0)),
+			limit:        uint64(settings.GetEndpointLimit(endpointKey)),
 			stepInterval: stepInterval,
 		}
 		if !settings.Serial {

--- a/cmd/stellar-rpc-blaster/internal/run/metrics/aggregator.go
+++ b/cmd/stellar-rpc-blaster/internal/run/metrics/aggregator.go
@@ -42,7 +42,7 @@ type EndpointStats struct {
 	percentiles  map[float64]time.Duration
 	startRPS     float64
 	targetRPS    float64
-	limit        uint64 // effective per-request limit; 0 for endpoints without pagination
+	limit        uint64        // effective per-request limit; 0 for endpoints without pagination
 	startTime    time.Time     // set on activation; zero means inactive
 	stepInterval time.Duration // window size for timeline snapshots
 	windows      []windowStats // per-step-interval accumulators
@@ -105,6 +105,7 @@ func NewAggregator(logger *log.Entry, settings config.Config, cancel context.Can
 	duration := settings.Duration
 	if settings.Serial {
 		duration *= time.Duration(len(endpoints))
+		duration += settings.Cooloff * time.Duration(max(len(endpoints)-1, 0)) // cooloff runs only between endpoints
 	}
 	a := Aggregator{
 		logger:          logger,

--- a/cmd/stellar-rpc-blaster/internal/run/metrics/results.go
+++ b/cmd/stellar-rpc-blaster/internal/run/metrics/results.go
@@ -24,6 +24,7 @@ type EndpointResult struct {
 	Success       uint64                 `json:"success"`
 	Errors        uint64                 `json:"errors"`
 	TargetRPS     float64                `json:"target_rps"`
+	Limit         uint64                 `json:"limit,omitempty"`
 	Percentiles   map[string]float64     `json:"percentiles_ms"`
 	ErrorTypes    map[string]ErrorResult `json:"error_types,omitempty"`
 	Timeline      []StepSnapshot         `json:"-"`
@@ -92,6 +93,7 @@ func (a *Aggregator) Results() *Results {
 			Errors:        stats.errors,
 			ErrorTypes:    errorTypesCopy,
 			TargetRPS:     stats.targetRPS,
+			Limit:         stats.limit,
 			Percentiles:   make(map[string]float64),
 			Timeline:      timeline,
 		}


### PR DESCRIPTION
### What

This PR makes several minor adjustments to the final JSON emitted by a `./stellar-rpc-blaster run ...`:
- change output location to top level `./output`
- if output path is provided and ends in .json, accept that as a literal `<filepath>/<filename>`
- for endpoints that are paginated and support a `limit` parameter, expose this limit in the final results JSON
- add `--cooloff <s>` parameter to allow a delay between endpoint blasts in `--serial` mode
- bump sample endpoints config toml

### Why

This tool is being used in performance evaluation infrastructure for `stellar-rpc` and these changes greatly reduce the gymnastics required to use the tool in a scripted manner.